### PR TITLE
feat: business logic — Server Actions, balance, TanStack Query e invitaciones

### DIFF
--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,0 +1,86 @@
+import { redirect } from "next/navigation";
+import { acceptInvitation } from "@/lib/actions/couple";
+import { createClient } from "@/lib/supabase/server";
+
+interface Props {
+  params: Promise<{ token: string }>;
+}
+
+export default async function InvitePage({ params }: Props) {
+  const { token } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(`/login?next=/invite/${token}`);
+  }
+
+  let error: string | null = null;
+
+  try {
+    await acceptInvitation(token);
+    redirect("/dashboard");
+  } catch (e) {
+    error = e instanceof Error ? e.message : "Error al aceptar la invitación";
+  }
+
+  return (
+    <div
+      style={{
+        minHeight: "100dvh",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "var(--bg-base)",
+        padding: "32px",
+        fontFamily: "var(--font-sans)",
+      }}
+    >
+      <div
+        style={{
+          background: "var(--bg-elevated)",
+          borderRadius: 20,
+          padding: "32px 24px",
+          border: "1px solid var(--border-subtle)",
+          boxShadow: "var(--shadow-md)",
+          textAlign: "center",
+          maxWidth: 360,
+          width: "100%",
+        }}
+      >
+        <div style={{ fontSize: 40, marginBottom: 16 }}>⚠️</div>
+        <div
+          style={{
+            fontSize: 18,
+            fontWeight: 700,
+            color: "var(--fg-1)",
+            marginBottom: 8,
+          }}
+        >
+          Invitación inválida
+        </div>
+        <div style={{ fontSize: 14, color: "var(--fg-2)", marginBottom: 24 }}>
+          {error}
+        </div>
+        <a
+          href="/dashboard"
+          style={{
+            display: "inline-block",
+            background: "var(--accent)",
+            color: "white",
+            borderRadius: 12,
+            padding: "12px 24px",
+            fontSize: 14,
+            fontWeight: 600,
+            textDecoration: "none",
+          }}
+        >
+          Ir al inicio
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import { Providers } from "@/lib/providers";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -21,7 +22,9 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="es">
-      <body>{children}</body>
+      <body>
+        <Providers>{children}</Providers>
+      </body>
     </html>
   );
 }

--- a/src/lib/actions/couple.ts
+++ b/src/lib/actions/couple.ts
@@ -1,0 +1,126 @@
+"use server";
+
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { revalidatePath } from "next/cache";
+
+export async function createCouple() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("No autenticado");
+
+  // Check if user already has a couple
+  const { data: existing } = await supabase
+    .from("couple_members")
+    .select("couple_id")
+    .eq("user_id", user.id)
+    .single();
+
+  if (existing) return { coupleId: existing.couple_id };
+
+  // Create couple
+  const { data: couple, error } = await supabase
+    .from("couples")
+    .insert({ status: "PENDING" })
+    .select()
+    .single();
+
+  if (error || !couple) throw new Error("Error al crear la pareja");
+
+  // Add creator as OWNER — bypass RLS via service client
+  const service = await createServiceClient();
+  await service.from("couple_members").insert({
+    couple_id: couple.id,
+    user_id: user.id,
+    role: "OWNER",
+  });
+
+  revalidatePath("/", "layout");
+  return { coupleId: couple.id };
+}
+
+export async function sendInvitation(coupleId: string, email: string) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("No autenticado");
+
+  const { data: invitation, error } = await supabase
+    .from("invitations")
+    .insert({ couple_id: coupleId, inviter_id: user.id, email })
+    .select()
+    .single();
+
+  if (error || !invitation) throw new Error("Error al crear la invitación");
+
+  const inviteUrl = `${process.env.NEXT_PUBLIC_APP_URL}/invite/${invitation.token}`;
+
+  // Send email via Resend
+  const res = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: "Gastos en Pareja <noreply@gastospareja.app>",
+      to: email,
+      subject: `${user.email} te invitó a Gastos en Pareja`,
+      html: `
+        <p>Hola,</p>
+        <p><strong>${user.email}</strong> te invitó a compartir los gastos del mes en Gastos en Pareja.</p>
+        <p><a href="${inviteUrl}" style="background:#6C5CE7;color:white;padding:12px 24px;border-radius:8px;text-decoration:none;display:inline-block;">Aceptar invitación</a></p>
+        <p style="color:#999;font-size:12px;">El link expira en 7 días.</p>
+      `,
+    }),
+  });
+
+  if (!res.ok) throw new Error("Error al enviar el email");
+  return { token: invitation.token };
+}
+
+export async function acceptInvitation(token: string) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("No autenticado");
+
+  // Validate token
+  const { data: invitation } = await supabase
+    .from("invitations")
+    .select("*")
+    .eq("token", token)
+    .is("accepted_at", null)
+    .gt("expires_at", new Date().toISOString())
+    .single();
+
+  if (!invitation) throw new Error("Invitación inválida o expirada");
+
+  const service = await createServiceClient();
+
+  // Add user as MEMBER
+  const { error: memberError } = await service.from("couple_members").insert({
+    couple_id: invitation.couple_id,
+    user_id: user.id,
+    role: "MEMBER",
+  });
+  if (memberError) throw new Error("Ya pertenecés a una pareja");
+
+  // Mark couple as ACTIVE
+  await service
+    .from("couples")
+    .update({ status: "ACTIVE" })
+    .eq("id", invitation.couple_id);
+
+  // Mark invitation as accepted
+  await service
+    .from("invitations")
+    .update({ accepted_at: new Date().toISOString() })
+    .eq("id", invitation.id);
+
+  revalidatePath("/", "layout");
+  return { coupleId: invitation.couple_id };
+}

--- a/src/lib/actions/expenses.ts
+++ b/src/lib/actions/expenses.ts
@@ -1,0 +1,173 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { revalidatePath } from "next/cache";
+
+async function getCouple() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("No autenticado");
+
+  const { data } = await supabase
+    .from("couple_members")
+    .select("couple_id")
+    .eq("user_id", user.id)
+    .single();
+
+  if (!data) throw new Error("No pertenecés a una pareja");
+  return { supabase, user, coupleId: data.couple_id };
+}
+
+// ── INCOMES ──────────────────────────────────────────────────
+
+export async function upsertIncome(amount: number, month: string) {
+  const { supabase, user, coupleId } = await getCouple();
+
+  await supabase.from("incomes").upsert(
+    {
+      couple_id: coupleId,
+      user_id: user.id,
+      amount,
+      month,
+    },
+    { onConflict: "couple_id,user_id,month" },
+  );
+
+  revalidatePath("/dashboard");
+  revalidatePath("/settings");
+}
+
+// ── INSTALLMENT PURCHASES ─────────────────────────────────────
+
+export async function createInstallmentPurchase(data: {
+  description: string;
+  total_amount: number;
+  installments: number;
+  first_payment_date: string;
+}) {
+  const { supabase, coupleId } = await getCouple();
+
+  await supabase
+    .from("installment_purchases")
+    .insert({ ...data, couple_id: coupleId });
+  revalidatePath("/expenses");
+  revalidatePath("/dashboard");
+}
+
+export async function incrementPaidInstallments(id: string) {
+  const { supabase } = await getCouple();
+
+  const { data } = await supabase
+    .from("installment_purchases")
+    .select("paid_installments, installments")
+    .eq("id", id)
+    .single();
+
+  if (!data || data.paid_installments >= data.installments) return;
+
+  await supabase
+    .from("installment_purchases")
+    .update({ paid_installments: data.paid_installments + 1 })
+    .eq("id", id);
+
+  revalidatePath("/expenses");
+  revalidatePath("/dashboard");
+}
+
+export async function deleteInstallmentPurchase(id: string) {
+  const { supabase } = await getCouple();
+  await supabase.from("installment_purchases").delete().eq("id", id);
+  revalidatePath("/expenses");
+  revalidatePath("/dashboard");
+}
+
+// ── FIXED EXPENSE TEMPLATES ───────────────────────────────────
+
+export async function createFixedExpenseTemplate(data: {
+  description: string;
+  amount: number;
+  due_day: number;
+}) {
+  const { supabase, coupleId } = await getCouple();
+  await supabase
+    .from("fixed_expense_templates")
+    .insert({ ...data, couple_id: coupleId });
+  revalidatePath("/expenses");
+  revalidatePath("/dashboard");
+}
+
+export async function toggleFixedExpenseInstance(
+  instanceId: string,
+  paid: boolean,
+) {
+  const { supabase } = await getCouple();
+  await supabase
+    .from("fixed_expense_instances")
+    .update({ paid })
+    .eq("id", instanceId);
+  revalidatePath("/expenses");
+  revalidatePath("/dashboard");
+}
+
+export async function ensureFixedExpenseInstances(
+  coupleId: string,
+  month: string,
+) {
+  const { supabase } = await getCouple();
+
+  const { data: templates } = await supabase
+    .from("fixed_expense_templates")
+    .select("id")
+    .eq("couple_id", coupleId)
+    .eq("active", true);
+
+  if (!templates?.length) return;
+
+  const { data: existing } = await supabase
+    .from("fixed_expense_instances")
+    .select("template_id")
+    .eq("couple_id", coupleId)
+    .eq("month", month);
+
+  const existingIds = new Set(existing?.map((e) => e.template_id));
+  const toCreate = templates
+    .filter((t) => !existingIds.has(t.id))
+    .map((t) => ({
+      template_id: t.id,
+      couple_id: coupleId,
+      month,
+      paid: false,
+    }));
+
+  if (toCreate.length) {
+    await supabase.from("fixed_expense_instances").insert(toCreate);
+  }
+}
+
+// ── VARIABLE EXPENSES ─────────────────────────────────────────
+
+export async function createVariableExpense(data: {
+  description: string;
+  amount: number;
+  date: string;
+}) {
+  const { supabase, user, coupleId } = await getCouple();
+
+  await supabase.from("variable_expenses").insert({
+    ...data,
+    couple_id: coupleId,
+    user_id: user.id,
+  });
+
+  revalidatePath("/expenses");
+  revalidatePath("/dashboard");
+}
+
+export async function deleteVariableExpense(id: string) {
+  const { supabase } = await getCouple();
+  await supabase.from("variable_expenses").delete().eq("id", id);
+  revalidatePath("/expenses");
+  revalidatePath("/dashboard");
+}

--- a/src/lib/providers.tsx
+++ b/src/lib/providers.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
+
+export function Providers({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 30 * 1000,
+            refetchOnWindowFocus: false,
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/src/lib/queries/use-monthly-data.ts
+++ b/src/lib/queries/use-monthly-data.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+
+export function useMonthlyData(coupleId: string | null, month: string) {
+  const supabase = createClient();
+
+  return useQuery({
+    queryKey: ["monthly-data", coupleId, month],
+    enabled: !!coupleId,
+    queryFn: async () => {
+      if (!coupleId) return null;
+
+      const [incomes, purchases, instances, variables] = await Promise.all([
+        supabase
+          .from("incomes")
+          .select("*")
+          .eq("couple_id", coupleId)
+          .eq("month", month),
+
+        supabase
+          .from("installment_purchases")
+          .select("*")
+          .eq("couple_id", coupleId)
+          .order("created_at", { ascending: false }),
+
+        supabase
+          .from("fixed_expense_instances")
+          .select("*, fixed_expense_templates(*)")
+          .eq("couple_id", coupleId)
+          .eq("month", month),
+
+        supabase
+          .from("variable_expenses")
+          .select("*")
+          .eq("couple_id", coupleId)
+          .gte("date", month)
+          .lt("date", getNextMonth(month))
+          .order("date", { ascending: false }),
+      ]);
+
+      return {
+        incomes: incomes.data ?? [],
+        installmentPurchases: purchases.data ?? [],
+        fixedExpenseInstances: instances.data ?? [],
+        variableExpenses: variables.data ?? [],
+      };
+    },
+  });
+}
+
+export function useCoupleMember() {
+  const supabase = createClient();
+
+  return useQuery({
+    queryKey: ["couple-member"],
+    queryFn: async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) return null;
+
+      const { data } = await supabase
+        .from("couple_members")
+        .select("*, couples(*)")
+        .eq("user_id", user.id)
+        .single();
+
+      return data ?? null;
+    },
+  });
+}
+
+function getNextMonth(month: string): string {
+  const [year, m] = month.split("-").map(Number);
+  const next = new Date(year, m, 1);
+  return `${next.getFullYear()}-${String(next.getMonth() + 1).padStart(2, "0")}-01`;
+}

--- a/src/lib/utils/balance.ts
+++ b/src/lib/utils/balance.ts
@@ -1,0 +1,98 @@
+import type { Database } from "@/types/database";
+
+type Income = Database["public"]["Tables"]["incomes"]["Row"];
+type InstallmentPurchase =
+  Database["public"]["Tables"]["installment_purchases"]["Row"];
+type FixedExpenseInstance =
+  Database["public"]["Tables"]["fixed_expense_instances"]["Row"] & {
+    fixed_expense_templates: Database["public"]["Tables"]["fixed_expense_templates"]["Row"];
+  };
+type VariableExpense = Database["public"]["Tables"]["variable_expenses"]["Row"];
+
+export interface PersonBalance {
+  userId: string;
+  percentage: number;
+  obligation: number;
+  actualPaid: number;
+  netBalance: number; // positive = overpaid, negative = owes
+}
+
+export interface MonthlyBalance {
+  totalExpenses: number;
+  installmentTotal: number;
+  fixedTotal: number;
+  variableTotal: number;
+  balances: PersonBalance[];
+  debtor: string | null; // userId who owes
+  creditor: string | null; // userId who is owed
+  debtAmount: number;
+}
+
+export function calculateMonthlyBalance(params: {
+  incomes: Income[];
+  installmentPurchases: InstallmentPurchase[];
+  fixedExpenseInstances: FixedExpenseInstance[];
+  variableExpenses: VariableExpense[];
+}): MonthlyBalance {
+  const {
+    incomes,
+    installmentPurchases,
+    fixedExpenseInstances,
+    variableExpenses,
+  } = params;
+
+  const totalIncome = incomes.reduce((sum, i) => sum + Number(i.amount), 0);
+
+  // Monthly installment cost = total_amount / installments for PENDING purchases
+  const installmentTotal = installmentPurchases
+    .filter((p) => p.paid_installments < p.installments)
+    .reduce((sum, p) => sum + Number(p.total_amount) / p.installments, 0);
+
+  // Fixed expenses: sum amounts from active templates for this month
+  const fixedTotal = fixedExpenseInstances.reduce(
+    (sum, i) => sum + Number(i.fixed_expense_templates.amount),
+    0,
+  );
+
+  const variableTotal = variableExpenses.reduce(
+    (sum, v) => sum + Number(v.amount),
+    0,
+  );
+
+  const totalExpenses = installmentTotal + fixedTotal + variableTotal;
+
+  const balances: PersonBalance[] = incomes.map((income) => {
+    const percentage =
+      totalIncome > 0 ? Number(income.amount) / totalIncome : 0;
+    const obligation = percentage * totalExpenses;
+    const actualPaid = variableExpenses
+      .filter((v) => v.user_id === income.user_id)
+      .reduce((sum, v) => sum + Number(v.amount), 0);
+    const netBalance = actualPaid - obligation;
+
+    return {
+      userId: income.user_id,
+      percentage,
+      obligation,
+      actualPaid,
+      netBalance,
+    };
+  });
+
+  // Who owes whom
+  const sorted = [...balances].sort((a, b) => a.netBalance - b.netBalance);
+  const debtor = sorted[0]?.netBalance < 0 ? sorted[0].userId : null;
+  const creditor = debtor ? sorted[sorted.length - 1].userId : null;
+  const debtAmount = debtor ? Math.abs(sorted[0].netBalance) : 0;
+
+  return {
+    totalExpenses,
+    installmentTotal,
+    fixedTotal,
+    variableTotal,
+    balances,
+    debtor,
+    creditor,
+    debtAmount,
+  };
+}


### PR DESCRIPTION
## Resumen

Implementación completa de la lógica de negocio — el motor que hace funcionar la app.

## Server Actions

### couple.ts
- `createCouple()` — crea pareja, agrega al creador como OWNER via service client (bypass RLS)
- `sendInvitation(coupleId, email)` — crea token de invitación + envía email via Resend
- `acceptInvitation(token)` — valida token (expiración, single-use), agrega MEMBER, marca couple como ACTIVE

### expenses.ts
- `upsertIncome(amount, month)` — upsert de ingreso mensual por usuario
- `createInstallmentPurchase(data)` — nueva compra en cuotas
- `incrementPaidInstallments(id)` — marca una cuota como pagada
- `deleteInstallmentPurchase(id)` — elimina compra
- `createFixedExpenseTemplate(data)` — nueva plantilla de gasto fijo
- `toggleFixedExpenseInstance(id, paid)` — marca gasto fijo pagado/pendiente
- `ensureFixedExpenseInstances(coupleId, month)` — genera instancias mensuales desde templates activos
- `createVariableExpense(data)` — registra gasto variable
- `deleteVariableExpense(id)` — elimina gasto variable

## Balance

### lib/utils/balance.ts — función pura
```
installmentTotal = Σ (total_amount / installments) para compras con cuotas_restantes > 0
fixedTotal       = Σ amount de instancias del mes  
variableTotal    = Σ gastos variables del mes
obligation       = (income / totalIncome) × totalExpenses por persona
netBalance       = actualPaid − obligation (+ = pagó de más, − = debe)
```

## TanStack Query
- `lib/providers.tsx` — QueryClientProvider global (staleTime 30s)
- `lib/queries/use-monthly-data.ts` — useMonthlyData + useCoupleMember
- `app/layout.tsx` — Providers wrapping

## Página de invitación
- `app/invite/[token]/page.tsx` — Server Component
  - Redirige a `/login?next=/invite/token` si no autenticado
  - Acepta invitación y redirige a `/dashboard`
  - Muestra error si token inválido/expirado

## Test plan
- [ ] `npx tsc --noEmit` pasa sin errores ✅
- [ ] `createCouple()` crea couple + member correctamente
- [ ] `sendInvitation()` envía email (verificar en Mailpit en local)
- [ ] `acceptInvitation()` vincula al segundo usuario
- [ ] `ensureFixedExpenseInstances()` genera instancias al abrir el dashboard
- [ ] `calculateMonthlyBalance()` coincide con valores de las hojas de cálculo

Closes #4