### PR TITLE
feat: seguridad — headers, CSP, rate limiting + elimina NEXT_PUBLIC_APP_URL

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,54 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+const supabaseHost = supabaseUrl ? new URL(supabaseUrl).host : "*.supabase.co";
+
+const ContentSecurityPolicy = `
+  default-src 'self';
+  script-src 'self' 'unsafe-inline' 'unsafe-eval';
+  style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+  font-src 'self' https://fonts.gstatic.com;
+  img-src 'self' data: blob: https://*.googleusercontent.com;
+  connect-src 'self'
+    https://${supabaseHost}
+    wss://${supabaseHost}
+    https://api.resend.com
+    https://accounts.google.com;
+  frame-src https://accounts.google.com;
+  object-src 'none';
+  base-uri 'self';
+  form-action 'self';
+  frame-ancestors 'none';
+  upgrade-insecure-requests;
+`
+  .replaceAll(/\s{2,}/g, " ")
+  .trim();
+
+const securityHeaders = [
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "X-DNS-Prefetch-Control", value: "on" },
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+  },
+  { key: "Content-Security-Policy", value: ContentSecurityPolicy },
+];
+
+const nextConfig: NextConfig = {
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: securityHeaders,
+      },
+    ];
+  },
+};
 
 export default nextConfig;

--- a/src/lib/actions/couple.ts
+++ b/src/lib/actions/couple.ts
@@ -47,6 +47,20 @@ export async function sendInvitation(coupleId: string, email: string) {
   } = await supabase.auth.getUser();
   if (!user) throw new Error("No autenticado");
 
+  // Rate limit: máx 5 invitaciones por usuario en la última hora
+  const oneHourAgo = new Date(Date.now() - 3_600_000).toISOString();
+  const { count } = await supabase
+    .from("invitations")
+    .select("id", { count: "exact", head: true })
+    .eq("inviter_id", user.id)
+    .gte("created_at", oneHourAgo);
+
+  if ((count ?? 0) >= 5) {
+    throw new Error(
+      "Límite de invitaciones alcanzado. Intentá de nuevo en una hora.",
+    );
+  }
+
   const { data: invitation, error } = await supabase
     .from("invitations")
     .insert({ couple_id: coupleId, inviter_id: user.id, email })
@@ -55,7 +69,12 @@ export async function sendInvitation(coupleId: string, email: string) {
 
   if (error || !invitation) throw new Error("Error al crear la invitación");
 
-  const inviteUrl = `${process.env.NEXT_PUBLIC_APP_URL}/invite/${invitation.token}`;
+  // Build invite URL from request headers — no NEXT_PUBLIC_APP_URL needed
+  const { headers } = await import("next/headers");
+  const h = await headers();
+  const host = h.get("host") ?? "localhost:3000";
+  const proto = process.env.NODE_ENV === "production" ? "https" : "http";
+  const inviteUrl = `${proto}://${host}/invite/${invitation.token}`;
 
   // Send email via Resend
   const res = await fetch("https://api.resend.com/emails", {


### PR DESCRIPTION
## Resumen

### Security Headers (next.config.ts)
| Header | Valor |
|--------|-------|
| X-Frame-Options | DENY |
| X-Content-Type-Options | nosniff |
| Referrer-Policy | strict-origin-when-cross-origin |
| HSTS | max-age=63072000; includeSubDomains; preload |
| Permissions-Policy | camera, mic, geolocation, interest-cohort bloqueados |
| CSP | connect-src Supabase+Resend, frame-src Google OAuth, font-src Google Fonts |

### Rate Limiting (couple.ts)
- `sendInvitation()`: máx 5 invitaciones por usuario por hora
- Implementado con query a Supabase — sin dependencia externa

### Eliminación de NEXT_PUBLIC_APP_URL (issue #13)
- `sendInvitation()` construye la URL desde `headers()` de Next.js
- El host se lee del header HTTP — correcto en dev y prod sin variable extra

## Test plan
- [ ] `npx tsc --noEmit` ✅
- [ ] Headers presentes en respuesta: verificar con DevTools → Network → Response Headers
- [ ] CSP no bloquea login Google, fuentes, ni llamadas Supabase
- [ ] 6ta invitación en una hora devuelve error de rate limit

Closes #6
Closes #13