### PR TITLE
feat: SEO — metadata, OG, Twitter Card, robots, sitemap y JSON-LD

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,10 @@
+User-agent: *
+Allow: /login
+Disallow: /dashboard
+Disallow: /expenses
+Disallow: /history
+Disallow: /settings
+Disallow: /invite/
+Disallow: /auth/
+
+Sitemap: https://gastospareja.app/sitemap.xml

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Iniciar sesión",
+  description:
+    "Ingresá a Gastos en Pareja y gestioná los gastos del mes con tu pareja de forma proporcional a los ingresos.",
+  robots: { index: true, follow: true }, // única ruta pública indexable
+  openGraph: {
+    title: "Gastos en Pareja — Iniciar sesión",
+    description:
+      "Gestioná los gastos del mes de forma proporcional a los ingresos de cada uno.",
+    type: "website",
+  },
+};
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  name: "Gastos en Pareja",
+  description:
+    "Aplicación para gestionar y distribuir los gastos mensuales en pareja de forma proporcional a los ingresos.",
+  applicationCategory: "FinanceApplication",
+  operatingSystem: "Web, Android, iOS",
+  offers: { "@type": "Offer", price: "0", priceCurrency: "ARS" },
+};
+
+export default function AuthLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,22 +2,46 @@ import type { Metadata, Viewport } from "next";
 import { Providers } from "@/lib/providers";
 import "./globals.css";
 
+const APP_NAME = "Gastos en Pareja";
+const APP_DESCRIPTION =
+  "Gestioná los gastos del mes de forma proporcional a los ingresos de cada uno.";
+const APP_URL = "https://gastospareja.app";
+
 export const metadata: Metadata = {
-  title: "Gastos en Pareja",
-  description:
-    "Gestioná los gastos del mes de forma proporcional a los ingresos de cada uno.",
+  applicationName: APP_NAME,
+  title: {
+    default: APP_NAME,
+    template: `%s — ${APP_NAME}`,
+  },
+  description: APP_DESCRIPTION,
   manifest: "/manifest.json",
   appleWebApp: {
     capable: true,
     statusBarStyle: "default",
-    title: "Gastos en Pareja",
+    title: APP_NAME,
   },
   formatDetection: { telephone: false },
   openGraph: {
     type: "website",
-    title: "Gastos en Pareja",
-    description: "Gestioná los gastos del mes de forma proporcional.",
+    siteName: APP_NAME,
+    title: APP_NAME,
+    description: APP_DESCRIPTION,
+    url: APP_URL,
+    images: [
+      { url: `${APP_URL}/icons/og-image.png`, width: 1200, height: 630 },
+    ],
   },
+  twitter: {
+    card: "summary",
+    title: APP_NAME,
+    description: APP_DESCRIPTION,
+  },
+  icons: {
+    icon: "/icons/icon-192.png",
+    apple: "/icons/icon-192.png",
+    shortcut: "/icons/icon-192.png",
+  },
+  robots: { index: false, follow: false }, // default noindex — overridden by login page
 };
 
 export const viewport: Viewport = {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: "https://gastospareja.app/login",
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 1,
+    },
+  ];
+}


### PR DESCRIPTION
## Resumen

SEO para la única ruta pública: `/login`. Todo lo demás está detrás de auth → noindex.

## Cambios

| Archivo | Qué hace |
|---------|---------|
| `app/layout.tsx` | title template, OG completo, Twitter Card, apple-touch-icon, robots noindex por defecto |
| `app/(auth)/layout.tsx` | Metadata indexable para /login + JSON-LD WebApplication |
| `public/robots.txt` | Allow /login, Disallow rutas auth, Sitemap URL |
| `app/sitemap.ts` | Solo /login en el sitemap |

## Pendiente antes del deploy
- `public/icons/icon-192.png` (192×192 PWA icon)
- `public/icons/icon-512.png` (512×512 PWA icon)  
- `public/icons/icon-maskable-512.png` (512×512 maskable)
- `public/icons/og-image.png` (1200×630 Open Graph)

## Test plan
- [ ] `npx tsc --noEmit` ✅
- [ ] `npm test` 10/10 ✅
- [ ] `/robots.txt` accesible y correcto
- [ ] `/sitemap.xml` generado por Next.js con solo /login
- [ ] JSON-LD visible en DevTools → Elements → `<script type="application/ld+json">`
- [ ] `<meta name="robots" content="index,follow">` en /login
- [ ] `<meta name="robots" content="noindex">` en /dashboard

Closes #7