### PR TITLE
fix: CSP y OAuth redirect para desarrollo local con Supabase

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
+const isDev = process.env.NODE_ENV === "development";
+
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
 const supabaseHost = supabaseUrl ? new URL(supabaseUrl).host : "*.supabase.co";
+
+// In dev, Supabase local runs on http:// — CSP must allow both protocols
+const supabaseConnectSrc = isDev
+  ? `https://${supabaseHost} http://${supabaseHost} wss://${supabaseHost} ws://${supabaseHost}`
+  : `https://${supabaseHost} wss://${supabaseHost}`;
 
 const ContentSecurityPolicy = `
   default-src 'self';
@@ -10,8 +17,7 @@ const ContentSecurityPolicy = `
   font-src 'self' https://fonts.gstatic.com;
   img-src 'self' data: blob: https://*.googleusercontent.com;
   connect-src 'self'
-    https://${supabaseHost}
-    wss://${supabaseHost}
+    ${supabaseConnectSrc}
     https://api.resend.com
     https://accounts.google.com;
   frame-src https://accounts.google.com;
@@ -19,7 +25,7 @@ const ContentSecurityPolicy = `
   base-uri 'self';
   form-action 'self';
   frame-ancestors 'none';
-  upgrade-insecure-requests;
+  ${isDev ? "" : "upgrade-insecure-requests;"}
 `
   .replaceAll(/\s{2,}/g, " ")
   .trim();
@@ -41,15 +47,9 @@ const securityHeaders = [
 ];
 
 const nextConfig: NextConfig = {
-  // Allow 127.0.0.1 for OAuth callbacks in local dev (Supabase local uses 127.0.0.1)
   allowedDevOrigins: ["127.0.0.1"],
   async headers() {
-    return [
-      {
-        source: "/(.*)",
-        headers: securityHeaders,
-      },
-    ];
+    return [{ source: "/(.*)", headers: securityHeaders }];
   },
 };
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -151,9 +151,13 @@ max_indexes = 5
 enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
-site_url = "http://127.0.0.1:3000"
+site_url = "http://localhost:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+additional_redirect_urls = [
+  "http://127.0.0.1:3000/auth/callback",
+  "http://localhost:3000/auth/callback",
+  "https://gastos-en-pareja.vercel.app/auth/callback"
+]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).


### PR DESCRIPTION
## Problema

Dos bugs que impedían el login con Google en local:

1. **CSP bloqueaba fetch a Supabase local** — el CSP solo permitía `https://` pero Supabase local corre en `http://`. El browser bloqueaba la conexión con `TypeError: Failed to fetch`.

2. **OAuth redirigía a `/login` en vez de `/auth/callback`** — `site_url` configurado como `127.0.0.1` causaba que el redirect post-OAuth fuera inconsistente.

## Fix

- `next.config.ts`: CSP `connect-src` permite `http://` y `ws://` en `NODE_ENV=development`. Producción sigue en `https://` únicamente.
- `supabase/config.toml`: `site_url` → `http://localhost:3000`, `additional_redirect_urls` incluye `/auth/callback` para localhost, 127.0.0.1 y el dominio de producción.

## Test plan

- [ ] Login con Google en `localhost:3000` funciona en el primer click
- [ ] URL post-login: `http://localhost:3000/dashboard` (no 127.0.0.1)
- [ ] Build de producción no se ve afectado (CSP http:// solo en dev)

Closes #20