### PR TITLE
test: TDD utils + E2E Playwright — golden path e auth

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Dashboard E2E tests.
+ *
+ * Pre-condition: dev server running + local Supabase up.
+ * Auth: Google OAuth is skipped — user must be logged in manually or via saved storage state.
+ * Run these tests after logging in once and saving auth state with:
+ *   npx playwright codegen --save-storage=e2e/auth.json http://localhost:3000
+ */
+
+test.describe("Dashboard", () => {
+  test("redirige a /login si no hay sesión", async ({ page }) => {
+    // Fresh context — no cookies
+    await page.goto("/dashboard");
+    await expect(page).toHaveURL(/login/);
+  });
+
+  test("página de login tiene el botón de Google", async ({ page }) => {
+    await page.goto("/login");
+    const btn = page.getByText("Continuar con Google");
+    await expect(btn).toBeVisible();
+  });
+
+  test("login page muestra el nombre de la app", async ({ page }) => {
+    await page.goto("/login");
+    await expect(page.getByText("Gastos en Pareja")).toBeVisible();
+  });
+
+  test("login page tiene las 3 feature pills", async ({ page }) => {
+    await page.goto("/login");
+    await expect(
+      page.getByText("Distribución proporcional a ingresos"),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Control de cuotas y gastos fijos"),
+    ).toBeVisible();
+    await expect(page.getByText("Sincronizado entre los dos")).toBeVisible();
+  });
+});
+
+test.describe("Navegación — sin sesión", () => {
+  test("todas las rutas protegidas redirigen a /login", async ({ page }) => {
+    for (const route of ["/dashboard", "/expenses", "/history", "/settings"]) {
+      await page.goto(route);
+      await expect(page).toHaveURL(/login/, { timeout: 5_000 });
+    }
+  });
+
+  test("/login no redirige (ruta pública)", async ({ page }) => {
+    await page.goto("/login");
+    await expect(page).toHaveURL(/login/);
+    await expect(page).not.toHaveURL(/dashboard/);
+  });
+});

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -1,0 +1,31 @@
+import { Page } from "@playwright/test";
+
+/**
+ * Seeds a Supabase session cookie directly into the browser so Playwright tests
+ * can skip the Google OAuth flow.
+ *
+ * Usage: call before navigating to any protected route.
+ */
+export async function seedSession(
+  page: Page,
+  accessToken: string,
+  refreshToken: string,
+) {
+  const supabaseUrl = "http://127.0.0.1:54321";
+
+  // Set Supabase session cookies directly (matches @supabase/ssr cookie format)
+  await page.context().addCookies([
+    {
+      name: `sb-${new URL(supabaseUrl).hostname.replaceAll(".", "-")}-auth-token`,
+      value: JSON.stringify({
+        access_token: accessToken,
+        refresh_token: refreshToken,
+        token_type: "bearer",
+      }),
+      domain: "localhost",
+      path: "/",
+      httpOnly: false,
+      secure: false,
+    },
+  ]);
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "prepare": "husky"
   },
   "lint-staged": {
@@ -40,6 +42,7 @@
   "devDependencies": {
     "@commitlint/cli": "^20.5.2",
     "@commitlint/config-conventional": "^20.5.0",
+    "@playwright/test": "^1.59.1",
     "@serwist/cli": "^9.5.7",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI
+    ? [["github"], ["html"]]
+    : [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  expect: { timeout: 7_000 },
+  projects: [
+    {
+      name: "chromium-mobile",
+      use: { ...devices["Pixel 5"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+  timeout: 30_000,
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -18,5 +18,6 @@ export function formatMonth(isoDate: string): string {
   const d = new Date(Number(year), Number(month) - 1);
   return d
     .toLocaleDateString("es-AR", { month: "long", year: "numeric" })
+    .replaceAll(/\s+de\s+/gi, " ") // Windows adds "de" between month and year
     .replace(/^\w/, (c) => c.toUpperCase());
 }

--- a/src/lib/utils/__tests__/utils.test.ts
+++ b/src/lib/utils/__tests__/utils.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { formatARS, getMonthDate, formatMonth } from "@/lib/utils";
+
+describe("formatARS", () => {
+  it("formatea números enteros con separador de miles (ARS)", () => {
+    expect(formatARS(1_320_004)).toBe("$1.320.004");
+  });
+
+  it("formatea cero", () => {
+    expect(formatARS(0)).toBe("$0");
+  });
+
+  it("formatea números pequeños sin separador", () => {
+    expect(formatARS(500)).toBe("$500");
+  });
+
+  it("redondea decimales al entero más cercano", () => {
+    // 55000.5 → 55001 en ARS con punto de miles: $55.001
+    expect(formatARS(55_000.5)).toBe("$55.001");
+  });
+
+  it("formatea montos reales de las hojas de cálculo", () => {
+    expect(formatARS(71_439)).toBe("$71.439");
+    expect(formatARS(39_169)).toBe("$39.169");
+    expect(formatARS(110_608)).toBe("$110.608");
+  });
+});
+
+describe("getMonthDate", () => {
+  it("retorna el primer día del mes actual en formato YYYY-MM-01", () => {
+    const result = getMonthDate();
+    expect(result).toMatch(/^\d{4}-\d{2}-01$/);
+  });
+
+  it("retorna el primer día del mes de la fecha dada", () => {
+    const date = new Date(2026, 3, 15); // 15 de abril 2026
+    expect(getMonthDate(date)).toBe("2026-04-01");
+  });
+
+  it("retorna el primer día de enero correctamente", () => {
+    const date = new Date(2026, 0, 31); // 31 de enero 2026
+    expect(getMonthDate(date)).toBe("2026-01-01");
+  });
+
+  it("padea el mes con cero si es de un dígito", () => {
+    const date = new Date(2026, 0, 1); // enero = mes 0
+    expect(getMonthDate(date)).toBe("2026-01-01");
+  });
+});
+
+describe("formatMonth", () => {
+  it("formatea fecha ISO a nombre de mes en español capitalizado", () => {
+    expect(formatMonth("2026-04-01")).toMatch(/^Abril 2026$/);
+  });
+
+  it("capitaliza la primera letra", () => {
+    const result = formatMonth("2026-01-01");
+    expect(result.charAt(0)).toBe(result.charAt(0).toUpperCase());
+  });
+
+  it("formatea diciembre correctamente", () => {
+    expect(formatMonth("2025-12-01")).toMatch(/^Diciembre 2025$/);
+  });
+
+  it("no incluye el número de día en el resultado", () => {
+    const result = formatMonth("2026-04-15");
+    expect(result).not.toMatch(/\b15\b/);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ import { resolve } from "path";
 export default defineConfig({
   test: {
     environment: "node",
+    exclude: ["**/node_modules/**", "**/e2e/**"],
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],


### PR DESCRIPTION
## Resumen

Tests no son deuda técnica — son parte del desarrollo.

## Unit Tests (Vitest) — 23 total ✅

### formatARS
- Formato ARS con separador de miles (punto)
- Redondeo sin decimales
- Valores reales de hojas de cálculo: $71.439, $39.169, $110.608

### getMonthDate
- Formato YYYY-MM-01, padding del mes

### formatMonth — bug real encontrado por TDD
- Windows agrega 'de' entre mes y año (ej: 'Abril de 2026')
- Fix en utils.ts: replaceAll(/\s+de\s+/gi, ' ')

## E2E (Playwright) — 6 tests ✅
- Dashboard redirige a /login sin sesión
- Login page: botón Google, nombre de la app, 3 feature pills
- Todas las rutas protegidas redirigen a /login
- /login es ruta pública

## Setup
- playwright.config.ts: mobile-first (Pixel 5), reuseExistingServer
- vitest.config.ts: exclude e2e/ para evitar conflicto
- npm run test:e2e para E2E / npm test para unit tests

Closes #25