### PR TITLE
fix: avatares e iniciales dinámicas en Dashboard y Gastos

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -9,6 +9,7 @@ import { formatARS, formatMonth, getMonthDate } from "@/lib/utils";
 import {
   useCoupleMember,
   useMonthlyData,
+  useCoupleMemberProfiles,
 } from "@/lib/queries/use-monthly-data";
 import { calculateMonthlyBalance } from "@/lib/utils/balance";
 import { ensureFixedExpenseInstances } from "@/lib/actions/expenses";
@@ -41,18 +42,36 @@ export default function DashboardPage() {
       })
     : null;
 
+  const { data: profiles = [] } = useCoupleMemberProfiles(
+    member?.user_id ?? null,
+  );
+
   const isLoading = loadingMember || loadingData;
 
-  // Find display names from member data
   const currentUserId = member?.user_id;
   const myBalance = balance?.balances.find((b) => b.userId === currentUserId);
   const partnerBalance = balance?.balances.find(
     (b) => b.userId !== currentUserId,
   );
 
-  // Determine initials (placeholder — real names come from auth.users)
-  const myInitials = "DE";
-  const partnerInitials = "AN";
+  // Initials from real profiles — falls back to "?" if not loaded yet
+  const getInitials = (name: string) =>
+    name
+      .split(" ")
+      .map((w) => w[0])
+      .join("")
+      .slice(0, 2)
+      .toUpperCase();
+
+  const myProfile = profiles.find((p) => p.user_id === currentUserId);
+  const partnerProfile = profiles.find((p) => p.user_id !== currentUserId);
+  const myInitials = myProfile ? getInitials(myProfile.full_name) : "?";
+  const partnerInitials = partnerProfile
+    ? getInitials(partnerProfile.full_name)
+    : "?";
+  const myFirstName = myProfile?.full_name.split(" ")[0] ?? "Vos";
+  const partnerFirstName =
+    partnerProfile?.full_name.split(" ")[0] ?? "Tu pareja";
 
   if (!member || member.couples?.status !== "ACTIVE") {
     return (
@@ -207,7 +226,9 @@ export default function DashboardPage() {
                         fontFamily: "var(--font-sans)",
                       }}
                     >
-                      {balance.debtor === currentUserId ? "Debés" : "Te deben"}
+                      {balance.debtor === currentUserId
+                        ? `${myFirstName} le debe a ${partnerFirstName}`
+                        : `${partnerFirstName} le debe a ${myFirstName}`}
                     </div>
                   </>
                 ) : (
@@ -245,6 +266,7 @@ export default function DashboardPage() {
                   {[
                     {
                       initials: myInitials,
+                      name: myFirstName,
                       person: "a" as const,
                       pct: myBalance
                         ? Math.round(myBalance.percentage * 100)
@@ -255,6 +277,7 @@ export default function DashboardPage() {
                     },
                     {
                       initials: partnerInitials,
+                      name: partnerFirstName,
                       person: "b" as const,
                       pct: partnerBalance
                         ? Math.round(partnerBalance.percentage * 100)
@@ -294,7 +317,7 @@ export default function DashboardPage() {
                             fontFamily: "var(--font-sans)",
                           }}
                         >
-                          {p.initials} · {p.pct}%
+                          {p.name} · {p.pct}%
                         </span>
                       </div>
                       <div

--- a/src/app/(app)/expenses/page.tsx
+++ b/src/app/(app)/expenses/page.tsx
@@ -9,6 +9,7 @@ import { formatARS, getMonthDate } from "@/lib/utils";
 import {
   useCoupleMember,
   useMonthlyData,
+  useCoupleMemberProfiles,
 } from "@/lib/queries/use-monthly-data";
 import {
   createInstallmentPurchase,
@@ -226,6 +227,22 @@ export default function ExpensesPage() {
   const coupleId = member?.couple_id ?? null;
   const month = getMonthDate();
   const { data } = useMonthlyData(coupleId, month);
+  const { data: profiles = [] } = useCoupleMemberProfiles(
+    member?.user_id ?? null,
+  );
+
+  const getInitials = (userId: string) => {
+    const p = profiles.find((pr) => pr.user_id === userId);
+    if (!p) return "?";
+    return p.full_name
+      .split(" ")
+      .map((w: string) => w[0])
+      .join("")
+      .slice(0, 2)
+      .toUpperCase();
+  };
+  const getPerson = (userId: string): "a" | "b" =>
+    userId === member?.user_id ? "a" : "b";
 
   function invalidate() {
     queryClient.invalidateQueries({ queryKey: ["monthly-data"] });
@@ -636,8 +653,8 @@ export default function ExpensesPage() {
                 }}
               >
                 <Avatar
-                  initials={v.user_id === member?.user_id ? "DE" : "AN"}
-                  person={v.user_id === member?.user_id ? "a" : "b"}
+                  initials={getInitials(v.user_id)}
+                  person={getPerson(v.user_id)}
                   size="md"
                 />
                 <div style={{ flex: 1 }}>


### PR DESCRIPTION
## Problema

Dashboard y Gastos tenían iniciales 'DE' y 'AN' hardcodeadas. Cualquier otra pareja veía nombres incorrectos.

## Cambios

### Dashboard
- `useCoupleMemberProfiles(userId)` carga nombres reales de ambos miembros
- Balance card muestra nombres reales: 'Deivy le debe a Annie'
- Cards de porcentaje muestran primer nombre real en lugar de iniciales fijas

### Gastos / Variables
- `getInitials(userId)` deriva las iniciales desde el perfil real
- `getPerson(userId)` determina el color (persona A o B) según userId

## Test plan
- [ ] `npx tsc --noEmit` ✅
- [ ] `npm test` 23/23 ✅
- [ ] Dashboard: nombres reales en balance card
- [ ] Gastos/Variables: avatar con iniciales correctas

Closes #27