### PR TITLE
test: E2E golden path autenticado — 13/13 GREEN

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,73 @@
+import { chromium, type FullConfig } from "@playwright/test";
+import { createClient } from "@supabase/supabase-js";
+
+// Local dev values — safe to commit (only work against http://127.0.0.1:54321)
+const SUPABASE_URL = process.env.E2E_SUPABASE_URL ?? "http://127.0.0.1:54321";
+const SUPABASE_SERVICE_KEY =
+  process.env.E2E_SUPABASE_SERVICE_KEY ??
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTY0MDAwMDAwMCwiZXhwIjoxOTgzODEyOTk2fQ.UTtkogysuF6fIO9e0N2rZeyhN4t33YHYny4OIa7yf08";
+
+// Test user credentials — used only against local Supabase, not production
+const TEST_EMAIL = process.env.E2E_TEST_EMAIL ?? "test@gastospareja.local";
+// NOSONAR: test-only password, never used in production
+const TEST_PASSWORD = process.env.E2E_TEST_PASSWORD ?? "Test1234!"; // NOSONAR
+
+export default async function globalSetup(_config: FullConfig) {
+  // 1. Ensure test couple exists in local DB
+  const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  const { data: users } = await admin.auth.admin.listUsers();
+  const testUser = users?.users.find((u) => u.email === TEST_EMAIL);
+  if (!testUser)
+    throw new Error(
+      `Test user ${TEST_EMAIL} not found. Run the setup script first.`,
+    );
+
+  const userId = testUser.id;
+  const { data: existing } = await admin
+    .from("couple_members")
+    .select("couple_id")
+    .eq("user_id", userId)
+    .single();
+
+  if (!existing) {
+    const { data: couple } = await admin
+      .from("couples")
+      .insert({ status: "ACTIVE" })
+      .select()
+      .single();
+    if (couple) {
+      await admin
+        .from("couple_members")
+        .insert({ couple_id: couple.id, user_id: userId, role: "OWNER" });
+    }
+  } else {
+    await admin
+      .from("couples")
+      .update({ status: "ACTIVE" })
+      .eq("id", existing.couple_id);
+  }
+
+  // 2. Sign in via the dev-only test endpoint (lets @supabase/ssr set cookies naturally)
+  const browser = await chromium.launch();
+  const context = await browser.newContext({
+    baseURL: "http://localhost:3000",
+  });
+  const page = await context.newPage();
+
+  const response = await page.request.post("/api/test/sign-in", {
+    headers: { "Content-Type": "application/json" },
+    data: { email: TEST_EMAIL, password: TEST_PASSWORD },
+  });
+
+  if (!response.ok()) {
+    const body = await response.text();
+    throw new Error(`Test sign-in failed: ${response.status()} ${body}`);
+  }
+
+  // 3. Save storage state with naturally-set auth cookies
+  await context.storageState({ path: "e2e/auth.json" });
+  await browser.close();
+}

--- a/e2e/happy-path.spec.ts
+++ b/e2e/happy-path.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Golden path E2E — usuario autenticado.
+ * Requiere: npm run dev + supabase start
+ * El global-setup crea el usuario de test y guarda auth.json
+ */
+
+test.use({ storageState: "e2e/auth.json" });
+
+test.describe("Happy path — usuario autenticado", () => {
+  test("redirige a /dashboard al estar autenticado", async ({ page }) => {
+    await page.goto("/");
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 });
+  });
+
+  test("dashboard carga con el balance del mes", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(page.getByText(/Balance/)).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("bottom nav tiene los 4 tabs", async ({ page }) => {
+    await page.goto("/dashboard");
+    const nav = page.locator("nav");
+    await expect(nav.getByText("Inicio")).toBeVisible();
+    await expect(nav.getByText("Gastos")).toBeVisible();
+    await expect(nav.getByText("Historial")).toBeVisible();
+    await expect(nav.getByText("Config")).toBeVisible();
+  });
+
+  test("navega a /expenses desde el bottom nav", async ({ page }) => {
+    await page.goto("/dashboard");
+    await page.locator("nav").getByText("Gastos").click();
+    await expect(page).toHaveURL(/expenses/);
+    // Verify the segmented control is visible (expenses-specific element)
+    await expect(page.getByRole("button", { name: "Cuotas" })).toBeVisible();
+  });
+
+  test("/expenses muestra las 3 tabs de tipos de gasto", async ({ page }) => {
+    await page.goto("/expenses");
+    await expect(page.getByRole("button", { name: "Cuotas" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Fijos" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Variables" })).toBeVisible();
+  });
+
+  test("agrega un gasto variable y aparece en la lista", async ({ page }) => {
+    await page.goto("/expenses");
+    await page.getByRole("button", { name: "Variables" }).click();
+
+    // Abrir FAB
+    await page.getByLabel("Agregar gasto").click();
+    await expect(page.getByText("Nuevo gasto — variables")).toBeVisible();
+
+    // Completar form
+    const inputs = page.locator("input");
+    await inputs.nth(0).fill("Test supermercado");
+    await inputs.nth(1).fill("5000");
+
+    await page.getByRole("button", { name: "Guardar" }).click();
+
+    // Verificar que aparece en la lista
+    await expect(page.getByText("Test supermercado")).toBeVisible({
+      timeout: 8_000,
+    });
+  });
+
+  test("cerrar sesión redirige a /login", async ({ page }) => {
+    await page.goto("/settings");
+    await page.getByText("Cerrar sesión").click();
+    await expect(page).toHaveURL(/login/, { timeout: 8_000 });
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./e2e",
+  globalSetup: "./e2e/global-setup.ts",
   fullyParallel: false,
   retries: process.env.CI ? 2 : 0,
   workers: 1,

--- a/src/app/api/test/sign-in/route.ts
+++ b/src/app/api/test/sign-in/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+import type { Database } from "@/types/database";
+
+// Only available in development — used by E2E tests to bypass Google OAuth
+export async function POST(request: Request) {
+  if (process.env.NODE_ENV !== "development") {
+    return NextResponse.json({ error: "Not available" }, { status: 404 });
+  }
+
+  const { email, password } = await request.json();
+  const cookieStore = await cookies();
+
+  const supabase = createServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll: () => cookieStore.getAll(),
+        setAll: (cookiesToSet) => {
+          cookiesToSet.forEach(({ name, value, options }) =>
+            cookieStore.set(name, value, options),
+          );
+        },
+      },
+    },
+  );
+
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  });
+  if (error)
+    return NextResponse.json({ error: error.message }, { status: 401 });
+
+  return NextResponse.json({ userId: data.user?.id });
+}


### PR DESCRIPTION
## Resumen

E2E del golden path autenticado. Completa el plan de testing del issue #30.

## Solución técnica

`@supabase/ssr` v0.10 almacena la sesión como `base64-{base64url(JSON)}` — inyectar cookies manualmente requería conocer el formato interno y era frágil. La solución: una route API dev-only `/api/test/sign-in` que usa el propio SDK para setear las cookies correctamente.

## Archivos

| Archivo | Descripción |
|---------|-------------|
| `e2e/global-setup.ts` | Setup global: verifica test user, crea pareja, hace sign-in via API route |
| `e2e/happy-path.spec.ts` | 7 tests del golden path autenticado |
| `src/app/api/test/sign-in/route.ts` | Route dev-only para E2E, retorna 404 en producción |
| `playwright.config.ts` | Agrega globalSetup |

## Tests

### Sin sesión (6) — ya existían
- Redirect a /login, login page UI

### Con sesión (7 — nuevos)
- Login → /dashboard
- Dashboard carga con balance
- Bottom nav 4 tabs
- Navega a /expenses
- /expenses tabs Cuotas/Fijos/Variables
- Agrega gasto variable → aparece en lista
- Cerrar sesión → /login

## Resultado
13/13 ✅ — 23 unit tests ✅

Closes #30