### PR TITLE
feat: categorías de gastos

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -10,8 +10,10 @@ import {
   useCoupleMember,
   useMonthlyData,
   useCoupleMemberProfiles,
+  useCategories,
 } from "@/lib/queries/use-monthly-data";
 import { calculateMonthlyBalance } from "@/lib/utils/balance";
+import { groupByCategory } from "@/lib/utils/categories";
 import { ensureFixedExpenseInstances } from "@/lib/actions/expenses";
 
 export default function DashboardPage() {
@@ -45,6 +47,28 @@ export default function DashboardPage() {
   const { data: profiles = [] } = useCoupleMemberProfiles(
     member?.user_id ?? null,
   );
+  const { data: categories = [] } = useCategories(coupleId);
+
+  const categoryBreakdown =
+    data && balance && balance.totalExpenses > 0
+      ? groupByCategory(
+          [
+            ...data.installmentPurchases.map((p) => ({
+              amount: Math.round(p.total_amount / p.installments),
+              category_id: p.category_id,
+            })),
+            ...data.fixedExpenseInstances.map((fi) => ({
+              amount: fi.fixed_expense_templates.amount,
+              category_id: fi.fixed_expense_templates.category_id,
+            })),
+            ...data.variableExpenses.map((v) => ({
+              amount: v.amount,
+              category_id: v.category_id,
+            })),
+          ],
+          categories,
+        ).slice(0, 5)
+      : [];
 
   const isLoading = loadingMember || loadingData;
 
@@ -477,6 +501,106 @@ export default function DashboardPage() {
                 </span>
               </div>
             </div>
+
+            {/* Breakdown por categoría */}
+            {categoryBreakdown.length > 0 && (
+              <div
+                style={{
+                  background: "var(--bg-elevated)",
+                  borderRadius: 16,
+                  border: "1px solid var(--border-subtle)",
+                  boxShadow: "var(--shadow-sm)",
+                  overflow: "hidden",
+                }}
+              >
+                <div
+                  style={{
+                    padding: "14px 16px",
+                    borderBottom: "1px solid var(--border-subtle)",
+                  }}
+                >
+                  <div
+                    style={{
+                      fontSize: 11,
+                      fontWeight: 600,
+                      color: "var(--fg-3)",
+                      textTransform: "uppercase",
+                      letterSpacing: "0.05em",
+                      fontFamily: "var(--font-sans)",
+                    }}
+                  >
+                    Por categoría
+                  </div>
+                </div>
+                <div
+                  style={{
+                    padding: "12px 16px",
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 8,
+                  }}
+                >
+                  {categoryBreakdown.map((g) => {
+                    const pct = balance
+                      ? Math.round((g.total / balance.totalExpenses) * 100)
+                      : 0;
+                    const color = g.category?.color ?? "#B2BEC3";
+                    const label = g.category
+                      ? `${g.category.icon} ${g.category.name}`
+                      : "📦 Sin categorizar";
+                    return (
+                      <div key={g.category?.id ?? "uncategorized"}>
+                        <div
+                          style={{
+                            display: "flex",
+                            justifyContent: "space-between",
+                            marginBottom: 3,
+                          }}
+                        >
+                          <span
+                            style={{
+                              fontSize: 12,
+                              color: "var(--fg-2)",
+                              fontFamily: "var(--font-sans)",
+                            }}
+                          >
+                            {label}
+                          </span>
+                          <span
+                            style={{
+                              fontSize: 12,
+                              fontWeight: 600,
+                              color: "var(--fg-1)",
+                              fontFamily: "var(--font-mono)",
+                            }}
+                          >
+                            {formatARS(g.total)}
+                          </span>
+                        </div>
+                        <div
+                          style={{
+                            background: "var(--bg-sunken)",
+                            borderRadius: 99,
+                            height: 5,
+                            overflow: "hidden",
+                          }}
+                        >
+                          <div
+                            style={{
+                              width: `${pct}%`,
+                              height: "100%",
+                              background: color,
+                              borderRadius: 99,
+                              transition: "width 400ms",
+                            }}
+                          />
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
 
             <Link
               href="/expenses"

--- a/src/app/(app)/expenses/page.tsx
+++ b/src/app/(app)/expenses/page.tsx
@@ -10,7 +10,9 @@ import {
   useCoupleMember,
   useMonthlyData,
   useCoupleMemberProfiles,
+  useCategories,
 } from "@/lib/queries/use-monthly-data";
+import { CategoryPicker } from "@/components/shared/category-picker";
 import {
   createInstallmentPurchase,
   incrementPaidInstallments,
@@ -76,14 +78,17 @@ function SegmentedControl({
 
 function AddSheet({
   tab,
+  categories,
   onClose,
   onSave,
 }: {
   tab: Tab;
+  categories: ReturnType<typeof useCategories>["data"];
   onClose: () => void;
-  onSave: (data: Record<string, string>) => void;
+  onSave: (data: Record<string, string>, categoryId: string | null) => void;
 }) {
   const [fields, setFields] = useState<Record<string, string>>({});
+  const [categoryId, setCategoryId] = useState<string | null>(null);
 
   const fieldDefs: Record<
     Tab,
@@ -195,8 +200,28 @@ function AddSheet({
             />
           </div>
         ))}
+        {categories && categories.length > 0 && (
+          <div style={{ marginBottom: 14 }}>
+            <div
+              style={{
+                fontSize: 13,
+                fontWeight: 500,
+                color: "var(--fg-2)",
+                marginBottom: 8,
+                fontFamily: "var(--font-sans)",
+              }}
+            >
+              Categoría
+            </div>
+            <CategoryPicker
+              categories={categories}
+              value={categoryId}
+              onChange={setCategoryId}
+            />
+          </div>
+        )}
         <button
-          onClick={() => onSave(fields)}
+          onClick={() => onSave(fields, categoryId)}
           style={{
             width: "100%",
             background: "var(--accent)",
@@ -230,6 +255,10 @@ export default function ExpensesPage() {
   const { data: profiles = [] } = useCoupleMemberProfiles(
     member?.user_id ?? null,
   );
+  const { data: categories = [] } = useCategories(coupleId);
+  const [filterCategory, setFilterCategory] = useState<string | null | "all">(
+    "all",
+  );
 
   const getInitials = (userId: string) => {
     const p = profiles.find((pr) => pr.user_id === userId);
@@ -248,7 +277,10 @@ export default function ExpensesPage() {
     queryClient.invalidateQueries({ queryKey: ["monthly-data"] });
   }
 
-  function handleSave(fields: Record<string, string>) {
+  function handleSave(
+    fields: Record<string, string>,
+    categoryId: string | null,
+  ) {
     setShowForm(false);
     startTransition(async () => {
       if (tab === "cuotas") {
@@ -258,27 +290,41 @@ export default function ExpensesPage() {
           installments: parseInt(fields.installments),
           first_payment_date:
             fields.first_payment_date || new Date().toISOString().slice(0, 10),
+          category_id: categoryId ?? undefined,
         });
       } else if (tab === "fijos") {
         await createFixedExpenseTemplate({
           description: fields.description,
           amount: parseFloat(fields.amount),
           due_day: parseInt(fields.due_day),
+          category_id: categoryId ?? undefined,
         });
       } else {
         await createVariableExpense({
           description: fields.description,
           amount: parseFloat(fields.amount),
           date: fields.date || new Date().toISOString().slice(0, 10),
+          category_id: categoryId ?? undefined,
         });
       }
       invalidate();
     });
   }
 
-  const cuotas = data?.installmentPurchases ?? [];
-  const fijos = data?.fixedExpenseInstances ?? [];
-  const variables = data?.variableExpenses ?? [];
+  const allCuotas = data?.installmentPurchases ?? [];
+  const allFijos = data?.fixedExpenseInstances ?? [];
+  const allVariables = data?.variableExpenses ?? [];
+
+  // Client-side filter by category
+  const cuotas =
+    filterCategory === "all"
+      ? allCuotas
+      : allCuotas.filter((c) => c.category_id === filterCategory);
+  const fijos = filterCategory === "all" ? allFijos : allFijos;
+  const variables =
+    filterCategory === "all"
+      ? allVariables
+      : allVariables.filter((v) => v.category_id === filterCategory);
 
   return (
     <div
@@ -699,6 +745,7 @@ export default function ExpensesPage() {
       {showForm && (
         <AddSheet
           tab={tab}
+          categories={categories}
           onClose={() => setShowForm(false)}
           onSave={handleSave}
         />

--- a/src/components/shared/category-picker.tsx
+++ b/src/components/shared/category-picker.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import type { Database } from "@/types/database";
+
+type Category = Database["public"]["Tables"]["expense_categories"]["Row"];
+
+interface CategoryPickerProps {
+  categories: Category[];
+  value: string | null;
+  onChange: (id: string | null) => void;
+}
+
+export function CategoryPicker({
+  categories,
+  value,
+  onChange,
+}: CategoryPickerProps) {
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+      <button
+        type="button"
+        onClick={() => onChange(null)}
+        style={{
+          padding: "5px 10px",
+          borderRadius: 99,
+          border: "none",
+          cursor: "pointer",
+          background: value === null ? "var(--accent)" : "var(--bg-sunken)",
+          color: value === null ? "white" : "var(--fg-2)",
+          fontSize: 12,
+          fontWeight: 500,
+          fontFamily: "var(--font-sans)",
+          minHeight: 32,
+        }}
+      >
+        Sin categoría
+      </button>
+      {categories.map((cat) => (
+        <button
+          key={cat.id}
+          type="button"
+          onClick={() => onChange(cat.id)}
+          style={{
+            padding: "5px 10px",
+            borderRadius: 99,
+            border: "none",
+            cursor: "pointer",
+            background: value === cat.id ? cat.color : "var(--bg-sunken)",
+            color: value === cat.id ? "white" : "var(--fg-2)",
+            fontSize: 12,
+            fontWeight: 500,
+            fontFamily: "var(--font-sans)",
+            minHeight: 32,
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+          }}
+        >
+          <span>{cat.icon}</span> {cat.name}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/actions/expenses.ts
+++ b/src/lib/actions/expenses.ts
@@ -46,6 +46,7 @@ export async function createInstallmentPurchase(data: {
   total_amount: number;
   installments: number;
   first_payment_date: string;
+  category_id?: string;
 }) {
   const { supabase, coupleId } = await getCouple();
 
@@ -89,6 +90,7 @@ export async function createFixedExpenseTemplate(data: {
   description: string;
   amount: number;
   due_day: number;
+  category_id?: string;
 }) {
   const { supabase, coupleId } = await getCouple();
   await supabase
@@ -152,6 +154,7 @@ export async function createVariableExpense(data: {
   description: string;
   amount: number;
   date: string;
+  category_id?: string;
 }) {
   const { supabase, user, coupleId } = await getCouple();
 

--- a/src/lib/queries/use-monthly-data.ts
+++ b/src/lib/queries/use-monthly-data.ts
@@ -72,6 +72,20 @@ export function useCoupleMember() {
   });
 }
 
+export function useCategories(coupleId: string | null) {
+  const supabase = createClient();
+  return useQuery({
+    queryKey: ["categories", coupleId],
+    queryFn: async () => {
+      const { data } = await supabase
+        .from("expense_categories")
+        .select("*")
+        .order("sort_order");
+      return data ?? [];
+    },
+  });
+}
+
 export function useCoupleMemberProfiles(userId: string | null) {
   const supabase = createClient();
   return useQuery({

--- a/src/lib/utils/__tests__/balance.test.ts
+++ b/src/lib/utils/__tests__/balance.test.ts
@@ -1,19 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { calculateMonthlyBalance } from "../balance";
 
-// Valores reales de las hojas de cálculo — oráculo de verdad
-// Hoja 1: Ingresos y distribución proporcional
-//   Deivy: $3.210.000 → 65%
-//   Annie: $1.760.000 → 35%
-//   Total gastos comunes: $110.608
-//   Deivy debe aportar: $71.895 (65% de $110.608)
-//   Annie debe aportar: $38.713 (35% de $110.608)
-//
-// Hoja 2: Compras en cuotas activas
-//   Aire Acondicionado: $1.320.004 / 24 cuotas = $55.000/mes (19 pagadas, 5 restantes)
-//   Ventiladores: $500.475 / 9 cuotas = $55.608/mes (3 pagadas, 6 restantes)
-//   Total cuotas activas: $110.608
-
 const DEIVY_ID = "user-deivy";
 const ANNIE_ID = "user-annie";
 
@@ -40,7 +27,8 @@ const baseInstallments = [
   {
     id: "p1",
     couple_id: "c1",
-    description: "Aire Acondicionado (005161)",
+    category_id: null,
+    description: "Aire Acondicionado",
     total_amount: 1_320_004,
     installments: 24,
     paid_installments: 19,
@@ -50,6 +38,7 @@ const baseInstallments = [
   {
     id: "p2",
     couple_id: "c1",
+    category_id: null,
     description: "Ventiladores",
     total_amount: 500_475,
     installments: 9,
@@ -68,7 +57,6 @@ describe("calculateMonthlyBalance", () => {
         fixedExpenseInstances: [],
         variableExpenses: [],
       });
-
       // round(1.320.004 / 24) + round(500.475 / 9) = $55.000 + $55.608 = $110.608
       expect(result.installmentTotal).toBe(110_608);
     });
@@ -80,12 +68,9 @@ describe("calculateMonthlyBalance", () => {
         fixedExpenseInstances: [],
         variableExpenses: [],
       });
-
       const deivy = result.balances.find((b) => b.userId === DEIVY_ID);
       const annie = result.balances.find((b) => b.userId === ANNIE_ID);
       if (!deivy || !annie) throw new Error("Balances no encontrados");
-
-      // 3.210.000 / 4.970.000 = 0.64588...
       expect(deivy.percentage).toBeCloseTo(0.6459, 3);
       expect(annie.percentage).toBeCloseTo(0.3541, 3);
     });
@@ -97,14 +82,10 @@ describe("calculateMonthlyBalance", () => {
         fixedExpenseInstances: [],
         variableExpenses: [],
       });
-
       const deivy = result.balances.find((b) => b.userId === DEIVY_ID);
       const annie = result.balances.find((b) => b.userId === ANNIE_ID);
       if (!deivy || !annie) throw new Error("Balances no encontrados");
-
-      // 64.588% × $110.608 = $71.439 (coincide con hoja: $71.439,28)
       expect(deivy.obligation).toBeCloseTo(71_439, 0);
-      // 35.412% × $110.608 = $39.169 (coincide con hoja: $39.169,20)
       expect(annie.obligation).toBeCloseTo(39_169, 0);
     });
 
@@ -114,6 +95,7 @@ describe("calculateMonthlyBalance", () => {
         {
           id: "p3",
           couple_id: "c1",
+          category_id: null,
           description: "Calefon (pagado)",
           total_amount: 578_000,
           installments: 1,
@@ -122,15 +104,12 @@ describe("calculateMonthlyBalance", () => {
           created_at: "",
         },
       ];
-
       const result = calculateMonthlyBalance({
         incomes: baseIncomes,
         installmentPurchases: withPaidPurchase,
         fixedExpenseInstances: [],
         variableExpenses: [],
       });
-
-      // El calefon pagado NO debe sumarse — total sigue siendo el mismo
       expect(result.installmentTotal).toBe(110_608);
     });
   });
@@ -148,6 +127,7 @@ describe("calculateMonthlyBalance", () => {
           fixed_expense_templates: {
             id: "t1",
             couple_id: "c1",
+            category_id: null,
             description: "Casita",
             amount: 500_000,
             due_day: 9,
@@ -165,6 +145,7 @@ describe("calculateMonthlyBalance", () => {
           fixed_expense_templates: {
             id: "t2",
             couple_id: "c1",
+            category_id: null,
             description: "EPEC",
             amount: 68_740,
             due_day: 31,
@@ -173,25 +154,23 @@ describe("calculateMonthlyBalance", () => {
           },
         },
       ];
-
       const result = calculateMonthlyBalance({
         incomes: baseIncomes,
         installmentPurchases: [],
         fixedExpenseInstances: fixedInstances,
         variableExpenses: [],
       });
-
       expect(result.fixedTotal).toBeCloseTo(568_740, 0);
     });
   });
 
   describe("gastos variables y balance final", () => {
     it("determina quién le debe a quién cuando hay gastos variables", () => {
-      // Si Annie pagó más de lo que le corresponde, Deivy le debe a Annie
       const variables = [
         {
           id: "v1",
           couple_id: "c1",
+          category_id: null,
           user_id: ANNIE_ID,
           description: "Supermercado",
           amount: 100_000,
@@ -199,19 +178,15 @@ describe("calculateMonthlyBalance", () => {
           created_at: "",
         },
       ];
-
       const result = calculateMonthlyBalance({
         incomes: baseIncomes,
         installmentPurchases: [],
         fixedExpenseInstances: [],
         variableExpenses: variables,
       });
-
-      // Annie pagó $100.000, su obligación = 35.41% × $100.000 = $35.412
-      // Annie overpagó → Deivy le debe a Annie
       const annie = result.balances.find((b) => b.userId === ANNIE_ID);
       if (!annie) throw new Error("Balance de Annie no encontrado");
-      expect(annie.netBalance).toBeGreaterThan(0); // overpaid
+      expect(annie.netBalance).toBeGreaterThan(0);
       expect(result.debtor).toBe(DEIVY_ID);
       expect(result.creditor).toBe(ANNIE_ID);
     });
@@ -221,6 +196,7 @@ describe("calculateMonthlyBalance", () => {
         {
           id: "v1",
           couple_id: "c1",
+          category_id: null,
           user_id: ANNIE_ID,
           description: "Supermercado",
           amount: 100_000,
@@ -228,16 +204,12 @@ describe("calculateMonthlyBalance", () => {
           created_at: "",
         },
       ];
-
       const result = calculateMonthlyBalance({
         incomes: baseIncomes,
         installmentPurchases: [],
         fixedExpenseInstances: [],
         variableExpenses: variables,
       });
-
-      // Deivy obligation = 64.59% × 100.000 = 64.590
-      // Deivy obligation = 64.588% × 100.000 = 64.588 → Deivy debe 64.588
       expect(result.debtAmount).toBeCloseTo(64_588, 0);
     });
   });
@@ -262,7 +234,6 @@ describe("calculateMonthlyBalance", () => {
           created_at: "",
         },
       ];
-
       expect(() =>
         calculateMonthlyBalance({
           incomes: zeroIncomes,
@@ -280,25 +251,21 @@ describe("calculateMonthlyBalance", () => {
         fixedExpenseInstances: [],
         variableExpenses: [],
       });
-
-      // Sin gastos variables, nadie pagó nada directamente
       expect(result.debtAmount).toBeGreaterThanOrEqual(0);
       expect(result.debtor).toBeNull();
     });
 
     it("maneja correctamente un solo miembro en la pareja", () => {
       const singleIncome = [baseIncomes[0]];
-
       const result = calculateMonthlyBalance({
         incomes: singleIncome,
         installmentPurchases: baseInstallments,
         fixedExpenseInstances: [],
         variableExpenses: [],
       });
-
       const deivy = result.balances[0];
       if (!deivy) throw new Error("Balance no encontrado");
-      expect(deivy.percentage).toBe(1); // 100%
+      expect(deivy.percentage).toBe(1);
       expect(deivy.obligation).toBe(110_608);
     });
   });

--- a/src/lib/utils/__tests__/categories.test.ts
+++ b/src/lib/utils/__tests__/categories.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { groupByCategory } from "../categories";
+import type { Database } from "@/types/database";
+
+type Category = Database["public"]["Tables"]["expense_categories"]["Row"];
+
+const makeCategory = (id: string, name: string): Category => ({
+  id,
+  name,
+  icon: "📦",
+  color: "#000",
+  couple_id: null,
+  sort_order: 0,
+  created_at: "",
+});
+
+const vivienda = makeCategory("cat-1", "Vivienda");
+const comida = makeCategory("cat-2", "Comida");
+const categories = [vivienda, comida];
+
+describe("groupByCategory", () => {
+  it("agrupa correctamente por categoría", () => {
+    const expenses = [
+      { amount: 100_000, category_id: "cat-1" },
+      { amount: 50_000, category_id: "cat-1" },
+      { amount: 30_000, category_id: "cat-2" },
+    ];
+    const result = groupByCategory(expenses, categories);
+
+    expect(result).toHaveLength(2);
+    const viv = result.find((r) => r.category?.id === "cat-1");
+    const com = result.find((r) => r.category?.id === "cat-2");
+    expect(viv?.total).toBe(150_000);
+    expect(com?.total).toBe(30_000);
+  });
+
+  it("gastos sin categoría se agrupan bajo null", () => {
+    const expenses = [
+      { amount: 5_000, category_id: null },
+      { amount: 3_000, category_id: null },
+    ];
+    const result = groupByCategory(expenses, categories);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBeNull();
+    expect(result[0].total).toBe(8_000);
+  });
+
+  it("mezcla de gastos con y sin categoría", () => {
+    const expenses = [
+      { amount: 80_000, category_id: "cat-1" },
+      { amount: 10_000, category_id: null },
+    ];
+    const result = groupByCategory(expenses, categories);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].total).toBe(80_000); // ordenado por total desc
+    expect(result[1].total).toBe(10_000);
+  });
+
+  it("categoría no encontrada en la lista retorna null", () => {
+    const expenses = [{ amount: 5_000, category_id: "unknown-id" }];
+    const result = groupByCategory(expenses, categories);
+
+    expect(result[0].category).toBeNull();
+    expect(result[0].total).toBe(5_000);
+  });
+
+  it("lista vacía de gastos retorna array vacío", () => {
+    expect(groupByCategory([], categories)).toHaveLength(0);
+  });
+});

--- a/src/lib/utils/categories.ts
+++ b/src/lib/utils/categories.ts
@@ -1,0 +1,34 @@
+import type { Database } from "@/types/database";
+
+type Category = Database["public"]["Tables"]["expense_categories"]["Row"];
+
+interface ExpenseWithCategory {
+  amount: number;
+  category_id: string | null;
+}
+
+export interface CategoryGroup {
+  category: Category | null;
+  total: number;
+}
+
+export function groupByCategory(
+  expenses: ExpenseWithCategory[],
+  categories: Category[],
+): CategoryGroup[] {
+  const map = new Map<string | null, number>();
+
+  for (const e of expenses) {
+    const key = e.category_id ?? null;
+    map.set(key, (map.get(key) ?? 0) + e.amount);
+  }
+
+  const result: CategoryGroup[] = [];
+
+  for (const [id, total] of map.entries()) {
+    const category = id ? (categories.find((c) => c.id === id) ?? null) : null;
+    result.push({ category, total });
+  }
+
+  return result.sort((a, b) => b.total - a.total);
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -84,6 +84,44 @@ export type Database = {
         };
         Relationships: [];
       };
+      expense_categories: {
+        Row: {
+          color: string;
+          couple_id: string | null;
+          created_at: string;
+          icon: string;
+          id: string;
+          name: string;
+          sort_order: number;
+        };
+        Insert: {
+          color?: string;
+          couple_id?: string | null;
+          created_at?: string;
+          icon?: string;
+          id?: string;
+          name: string;
+          sort_order?: number;
+        };
+        Update: {
+          color?: string;
+          couple_id?: string | null;
+          created_at?: string;
+          icon?: string;
+          id?: string;
+          name?: string;
+          sort_order?: number;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "expense_categories_couple_id_fkey";
+            columns: ["couple_id"];
+            isOneToOne: false;
+            referencedRelation: "couples";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       fixed_expense_instances: {
         Row: {
           couple_id: string;
@@ -130,6 +168,7 @@ export type Database = {
         Row: {
           active: boolean;
           amount: number;
+          category_id: string | null;
           couple_id: string;
           created_at: string;
           description: string;
@@ -139,6 +178,7 @@ export type Database = {
         Insert: {
           active?: boolean;
           amount: number;
+          category_id?: string | null;
           couple_id: string;
           created_at?: string;
           description: string;
@@ -148,6 +188,7 @@ export type Database = {
         Update: {
           active?: boolean;
           amount?: number;
+          category_id?: string | null;
           couple_id?: string;
           created_at?: string;
           description?: string;
@@ -155,6 +196,13 @@ export type Database = {
           id?: string;
         };
         Relationships: [
+          {
+            foreignKeyName: "fixed_expense_templates_category_id_fkey";
+            columns: ["category_id"];
+            isOneToOne: false;
+            referencedRelation: "expense_categories";
+            referencedColumns: ["id"];
+          },
           {
             foreignKeyName: "fixed_expense_templates_couple_id_fkey";
             columns: ["couple_id"];
@@ -201,6 +249,7 @@ export type Database = {
       };
       installment_purchases: {
         Row: {
+          category_id: string | null;
           couple_id: string;
           created_at: string;
           description: string;
@@ -211,6 +260,7 @@ export type Database = {
           total_amount: number;
         };
         Insert: {
+          category_id?: string | null;
           couple_id: string;
           created_at?: string;
           description: string;
@@ -221,6 +271,7 @@ export type Database = {
           total_amount: number;
         };
         Update: {
+          category_id?: string | null;
           couple_id?: string;
           created_at?: string;
           description?: string;
@@ -231,6 +282,13 @@ export type Database = {
           total_amount?: number;
         };
         Relationships: [
+          {
+            foreignKeyName: "installment_purchases_category_id_fkey";
+            columns: ["category_id"];
+            isOneToOne: false;
+            referencedRelation: "expense_categories";
+            referencedColumns: ["id"];
+          },
           {
             foreignKeyName: "installment_purchases_couple_id_fkey";
             columns: ["couple_id"];
@@ -284,6 +342,7 @@ export type Database = {
       variable_expenses: {
         Row: {
           amount: number;
+          category_id: string | null;
           couple_id: string;
           created_at: string;
           date: string;
@@ -293,6 +352,7 @@ export type Database = {
         };
         Insert: {
           amount: number;
+          category_id?: string | null;
           couple_id: string;
           created_at?: string;
           date?: string;
@@ -302,6 +362,7 @@ export type Database = {
         };
         Update: {
           amount?: number;
+          category_id?: string | null;
           couple_id?: string;
           created_at?: string;
           date?: string;
@@ -310,6 +371,13 @@ export type Database = {
           user_id?: string;
         };
         Relationships: [
+          {
+            foreignKeyName: "variable_expenses_category_id_fkey";
+            columns: ["category_id"];
+            isOneToOne: false;
+            referencedRelation: "expense_categories";
+            referencedColumns: ["id"];
+          },
           {
             foreignKeyName: "variable_expenses_couple_id_fkey";
             columns: ["couple_id"];

--- a/supabase/migrations/20260428223559_expense_categories.sql
+++ b/supabase/migrations/20260428223559_expense_categories.sql
@@ -1,0 +1,46 @@
+-- ── EXPENSE CATEGORIES ────────────────────────────────────────
+-- couple_id = NULL → categoría del sistema (visible para todos)
+-- couple_id = id   → categoría personalizada de la pareja
+
+create table public.expense_categories (
+  id         uuid primary key default gen_random_uuid(),
+  couple_id  uuid references public.couples(id) on delete cascade,
+  name       text not null,
+  icon       text not null default '📦',
+  color      text not null default '#6C5CE7',
+  sort_order int  not null default 0,
+  created_at timestamptz not null default now()
+);
+
+create index on public.expense_categories (couple_id);
+
+-- Sistema predefinidas (couple_id = NULL)
+insert into public.expense_categories (couple_id, name, icon, color, sort_order) values
+  (null, 'Vivienda',        '🏠', '#6C5CE7', 1),
+  (null, 'Servicios',       '💡', '#00B894', 2),
+  (null, 'Comida',          '🛒', '#FDCB6E', 3),
+  (null, 'Transporte',      '🚗', '#74B9FF', 4),
+  (null, 'Salud',           '❤️',  '#E17055', 5),
+  (null, 'Entretenimiento', '🎬', '#A29BFE', 6),
+  (null, 'Educación',       '📚', '#55EFC4', 7),
+  (null, 'Otros',           '📦', '#B2BEC3', 8);
+
+-- FKs opcionales en las 3 tablas de gastos
+alter table public.installment_purchases   add column category_id uuid references public.expense_categories(id);
+alter table public.fixed_expense_templates add column category_id uuid references public.expense_categories(id);
+alter table public.variable_expenses       add column category_id uuid references public.expense_categories(id);
+
+-- RLS
+alter table public.expense_categories enable row level security;
+
+create policy "categories: read sistema y propia pareja" on public.expense_categories
+  for select using (
+    couple_id is null
+    or public.is_couple_member(couple_id)
+  );
+
+create policy "categories: pareja puede crear propias" on public.expense_categories
+  for insert with check (
+    couple_id is not null
+    and public.is_couple_member(couple_id)
+  );


### PR DESCRIPTION
## Resumen

Categorías opcionales para los tres tipos de gastos. Incluye 8 categorías predefinidas del sistema y breakdown visual en el dashboard.

## Schema

- `expense_categories`: tabla con categorías del sistema (`couple_id = NULL`) y personalizadas por pareja
- FK nullable `category_id` en `installment_purchases`, `fixed_expense_templates`, `variable_expenses`
- RLS: categorías del sistema visibles para todos; personalizadas solo para la pareja

## Cambios

| Archivo | Cambio |
|---------|--------|
| `supabase/migrations/...expense_categories.sql` | Schema + seed + FKs + RLS |
| `src/lib/utils/categories.ts` | `groupByCategory()` función pura |
| `src/lib/utils/__tests__/categories.test.ts` | 5 tests unitarios |
| `src/lib/queries/use-monthly-data.ts` | `useCategories(coupleId)` hook |
| `src/lib/actions/expenses.ts` | Acepta `category_id?` en 3 Server Actions |
| `src/components/shared/category-picker.tsx` | Selector visual con icon+nombre+color |
| `src/app/(app)/expenses/page.tsx` | CategoryPicker en AddSheet + filtro client-side |
| `src/app/(app)/dashboard/page.tsx` | Breakdown por categoría con barras HTML |

## Test plan

- [ ] `npx tsc --noEmit` — 0 errores ✅
- [ ] `npm test` — 28/28 ✅ (5 nuevos para groupByCategory)
- [ ] Agregar gasto con categoría → aparece con la categoría en la lista
- [ ] Filtrar por categoría en /expenses → solo muestra los de esa categoría
- [ ] Dashboard → breakdown visible si hay gastos con categoría

Closes #31