### PR TITLE
chore: agrega archivos Playwright al .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 
 # testing
 /coverage
+/playwright-report/
+/test-results/
+e2e/auth.json
 
 # next.js
 /.next/


### PR DESCRIPTION
Playwright genera tres tipos de archivos locales que no deben versionarse:

- `e2e/auth.json`: storage state con tokens de sesión del usuario de test (datos sensibles)
- `playwright-report/`: reportes HTML de los últimos tests
- `test-results/`: screenshots y videos de tests fallidos

Closes #37