### PR TITLE
fix: cambia from de Resend a onboarding@resend.dev

### DIFF
--- a/src/lib/actions/couple.ts
+++ b/src/lib/actions/couple.ts
@@ -74,7 +74,7 @@ export async function sendInvitation(coupleId: string, email: string) {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      from: "Gastos en Pareja <noreply@gastospareja.app>",
+      from: "Gastos en Pareja <onboarding@resend.dev>",
       to: email,
       subject: `${user.email} te invitó a Gastos en Pareja`,
       html: `


### PR DESCRIPTION
## Problema
`sendInvitation()` falla en producción con 500. El dominio `gastospareja.app` no está verificado en Resend, por lo que rechaza el envío desde `noreply@gastospareja.app`.

## Fix
Usa `onboarding@resend.dev` — dominio de prueba de Resend que funciona sin verificación.

## Fix permanente (pendiente)
1. Ir a resend.com → Domains → Add Domain → `gastospareja.app`
2. Configurar DNS records
3. Cambiar el `from` de vuelta a `noreply@gastospareja.app`

Closes #39