### PR TITLE
fix: mejorar mensaje de error al enviar invitación por email

### DIFF
--- a/src/lib/actions/couple.ts
+++ b/src/lib/actions/couple.ts
@@ -86,7 +86,10 @@ export async function sendInvitation(coupleId: string, email: string) {
     }),
   });
 
-  if (!res.ok) throw new Error("Error al enviar el email");
+  if (!res.ok) {
+    const body = await res.text().catch(() => "(no body)");
+    throw new Error(`Error al enviar el email (${res.status}): ${body}`);
+  }
   return { token: invitation.token };
 }
 


### PR DESCRIPTION
## Descripción

Al fallar el envío de email con Resend, el error capturado no incluía el código HTTP ni el cuerpo de la respuesta, lo que hacía imposible diagnosticar la causa real del fallo en producción.

## Cambios

- El mensaje de error ahora incluye el código de estado HTTP y el cuerpo de la respuesta de Resend
- Facilita el diagnóstico cuando RESEND_API_KEY falta o es inválida en producción

## Causa raíz

La variable de entorno RESEND_API_KEY estaba ausente en Vercel producción. El guard NODE_ENV === 'production' impedía detectar el problema en local.

## Pasos adicionales necesarios

⚠️ Agregar RESEND_API_KEY en las variables de entorno de Vercel producción.

Closes #42