### PR TITLE
feat(email): migrate to Brevo with provider-agnostic abstraction

### DIFF
--- a/src/lib/actions/couple.ts
+++ b/src/lib/actions/couple.ts
@@ -2,6 +2,7 @@
 
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
+import { sendEmail } from "@/lib/utils/email";
 
 export async function createCouple() {
   const supabase = await createClient();
@@ -61,35 +62,17 @@ export async function sendInvitation(coupleId: string, email: string) {
   const proto = process.env.NODE_ENV === "production" ? "https" : "http";
   const inviteUrl = `${proto}://${host}/invite/${invitation.token}`;
 
-  // In dev: skip Resend and log the invite URL to the terminal (like Mailpit)
-  if (process.env.NODE_ENV !== "production") {
-    console.log(`\n📧 [DEV] Invitación para ${email}:\n   ${inviteUrl}\n`);
-    return { token: invitation.token };
-  }
-
-  const res = await fetch("https://api.resend.com/emails", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      from: "Gastos en Pareja <onboarding@resend.dev>",
-      to: email,
-      subject: `${user.email} te invitó a Gastos en Pareja`,
-      html: `
-        <p>Hola,</p>
-        <p><strong>${user.email}</strong> te invitó a compartir los gastos del mes en Gastos en Pareja.</p>
-        <p><a href="${inviteUrl}" style="background:#6C5CE7;color:white;padding:12px 24px;border-radius:8px;text-decoration:none;display:inline-block;">Aceptar invitación</a></p>
-        <p style="color:#999;font-size:12px;">El link expira en 7 días.</p>
-      `,
-    }),
+  await sendEmail({
+    to: email,
+    subject: `${user.email} te invitó a Gastos en Pareja`,
+    html: `
+      <p>Hola,</p>
+      <p><strong>${user.email}</strong> te invitó a compartir los gastos del mes en Gastos en Pareja.</p>
+      <p><a href="${inviteUrl}" style="background:#6C5CE7;color:white;padding:12px 24px;border-radius:8px;text-decoration:none;display:inline-block;">Aceptar invitación</a></p>
+      <p style="color:#999;font-size:12px;">El link expira en 7 días.</p>
+    `,
   });
 
-  if (!res.ok) {
-    const body = await res.text().catch(() => "(no body)");
-    throw new Error(`Error al enviar el email (${res.status}): ${body}`);
-  }
   return { token: invitation.token };
 }
 

--- a/src/lib/utils/email.ts
+++ b/src/lib/utils/email.ts
@@ -1,0 +1,95 @@
+interface SendEmailOptions {
+  to: string;
+  subject: string;
+  html: string;
+}
+
+// ---------------------------------------------------------------------------
+// Providers
+// ---------------------------------------------------------------------------
+
+async function sendViaBrevo({
+  to,
+  subject,
+  html,
+}: SendEmailOptions): Promise<void> {
+  const res = await fetch("https://api.brevo.com/v3/smtp/email", {
+    method: "POST",
+    headers: {
+      "api-key": process.env.BREVO_API_KEY!,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      sender: {
+        name: process.env.EMAIL_SENDER_NAME ?? "Gastos en Pareja",
+        email: process.env.EMAIL_SENDER_ADDRESS!,
+      },
+      to: [{ email: to }],
+      subject,
+      htmlContent: html,
+    }),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "(no body)");
+    throw new Error(`Brevo error (${res.status}): ${body}`);
+  }
+}
+
+async function sendViaResend({
+  to,
+  subject,
+  html,
+}: SendEmailOptions): Promise<void> {
+  const from = `${process.env.EMAIL_SENDER_NAME ?? "Gastos en Pareja"} <${process.env.EMAIL_SENDER_ADDRESS}>`;
+  const res = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ from, to: [to], subject, html }),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "(no body)");
+    throw new Error(`Resend error (${res.status}): ${body}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Provider-agnostic email sender.
+ *
+ * In dev:        logs to terminal (no emails sent).
+ * In production: dispatches to the provider set in EMAIL_PROVIDER env var.
+ *
+ * Env vars:
+ *   EMAIL_PROVIDER       — "brevo" (default) | "resend"
+ *   EMAIL_SENDER_NAME    — display name for the From field
+ *   EMAIL_SENDER_ADDRESS — sender email address
+ *   BREVO_API_KEY        — required when EMAIL_PROVIDER=brevo
+ *   RESEND_API_KEY       — required when EMAIL_PROVIDER=resend
+ */
+export async function sendEmail(options: SendEmailOptions): Promise<void> {
+  if (process.env.NODE_ENV !== "production") {
+    console.log(
+      `\n📧 [DEV] Email para ${options.to}\n   Subject: ${options.subject}\n`,
+    );
+    return;
+  }
+
+  const provider = process.env.EMAIL_PROVIDER ?? "brevo";
+
+  switch (provider) {
+    case "brevo":
+      return sendViaBrevo(options);
+    case "resend":
+      return sendViaResend(options);
+    default:
+      throw new Error(
+        `Email provider desconocido: "${provider}". Valores válidos: brevo, resend`,
+      );
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #50 — Resend 403 due to unverified domain.

## Changes

- **src/lib/utils/email.ts** (new): provider-agnostic \sendEmail()\ — dispatches to Brevo or Resend via \EMAIL_PROVIDER\ env var. Dev guard skips send in non-production.
- **\src/lib/actions/couple.ts\** (modified): uses \sendEmail()\ instead of direct Resend call.

## Env vars (already set in Vercel production)

| Var | Value |
|-----|-------|
| \EMAIL_PROVIDER\ | \revo\ |
| \EMAIL_SENDER_NAME\ | \Gastos en Pareja\ |
| \EMAIL_SENDER_ADDRESS\ | \deivy.gutierrez@gmail.com\ |
| \BREVO_API_KEY\ | (secret) |