### PR TITLE
chore: ignore .gga and generated sw.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,9 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# GGA (Gentleman Guardian Angel) AI code review config
+.gga
+
+# Serwist generated service worker
+/public/sw.js


### PR DESCRIPTION
Closes #53

## Summary
- Add `.gga` to `.gitignore`
- Add `/public/sw.js` to `.gitignore`

## Notes
This keeps local and generated files out of version control.