### PR TITLE
release: v1.5.0 — security hardening, invite flow fixes, a11y

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -31,7 +31,7 @@ function getInitials(name: string) {
 
 // ── SUB-COMPONENTS ────────────────────────────────────────────
 
-function NoCoupleState({ hasMember }: { hasMember: boolean }) {
+function NoCoupleState({ hasMember }: { readonly hasMember: boolean }) {
   return (
     <div
       style={{
@@ -90,8 +90,8 @@ function NewInstancesBanner({
   count,
   onDismiss,
 }: {
-  count: number;
-  onDismiss: () => void;
+  readonly count: number;
+  readonly onDismiss: () => void;
 }) {
   if (count === 0) return null;
   const plural = count > 1;
@@ -141,10 +141,10 @@ function BalanceCard({
   myProfile,
   partnerProfile,
 }: {
-  balance: MonthlyBalance;
-  month: string;
-  myProfile: Profile | undefined;
-  partnerProfile: Profile | undefined;
+  readonly balance: MonthlyBalance;
+  readonly month: string;
+  readonly myProfile: Profile | undefined;
+  readonly partnerProfile: Profile | undefined;
 }) {
   const myInitials = myProfile ? getInitials(myProfile.full_name) : "?";
   const partnerInitials = partnerProfile
@@ -328,7 +328,7 @@ function BalanceCard({
   );
 }
 
-function MonthSummaryCard({ balance }: { balance: MonthlyBalance }) {
+function MonthSummaryCard({ balance }: { readonly balance: MonthlyBalance }) {
   const rows = [
     {
       label: "Cuotas activas",
@@ -456,8 +456,8 @@ function CategoryBreakdownCard({
   breakdown,
   total,
 }: {
-  breakdown: CategoryGroup[];
-  total: number;
+  readonly breakdown: CategoryGroup[];
+  readonly total: number;
 }) {
   if (breakdown.length === 0) return null;
   return (
@@ -622,7 +622,8 @@ export default function DashboardPage() {
   }
 
   return (
-    <div
+    <main
+      aria-label="Inicio"
       style={{
         display: "flex",
         flexDirection: "column",
@@ -707,6 +708,6 @@ export default function DashboardPage() {
           </>
         )}
       </div>
-    </div>
+    </main>
   );
 }

--- a/src/app/(app)/expenses/page.tsx
+++ b/src/app/(app)/expenses/page.tsx
@@ -4,7 +4,7 @@ import { useState, useTransition } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Avatar } from "@/components/shared/avatar";
 import { Badge } from "@/components/shared/badge";
-import { FAB } from "@/components/shared/fab";
+import { FAB as Fab } from "@/components/shared/fab";
 import { formatARS, getMonthDate } from "@/lib/utils";
 import {
   useCoupleMember,
@@ -27,8 +27,8 @@ function SegmentedControl({
   active,
   onChange,
 }: {
-  active: Tab;
-  onChange: (t: Tab) => void;
+  readonly active: Tab;
+  readonly onChange: (t: Tab) => void;
 }) {
   return (
     <div
@@ -82,10 +82,10 @@ function AddSheet({
   onClose,
   onSave,
 }: {
-  tab: Tab;
-  categories: ReturnType<typeof useCategories>["data"];
-  onClose: () => void;
-  onSave: (
+  readonly tab: Tab;
+  readonly categories: ReturnType<typeof useCategories>["data"];
+  readonly onClose: () => void;
+  readonly onSave: (
     data: Record<string, string>,
     categoryId: string | null,
     autoRenew: boolean,
@@ -122,27 +122,38 @@ function AddSheet({
   };
 
   return (
-    <div
-      style={{
-        position: "fixed",
-        inset: 0,
-        background: "var(--bg-overlay)",
-        zIndex: 200,
-        display: "flex",
-        alignItems: "flex-end",
-      }}
-      onClick={onClose}
-    >
+    <>
+      {/* Backdrop */}
       <div
+        aria-hidden="true"
         style={{
+          position: "fixed",
+          inset: 0,
+          background: "var(--bg-overlay)",
+          zIndex: 200,
+        }}
+        onClick={onClose}
+      />
+      {/* Sheet */}
+      {/* biome-ignore lint/a11y/noNoninteractiveEventListener: <dialog> is a native interactive element */}
+      <dialog
+        open
+        aria-label="Agregar gasto"
+        style={{
+          position: "fixed",
+          bottom: 0,
+          left: "50%",
+          transform: "translateX(-50%)",
           background: "var(--bg-elevated)",
           borderRadius: "20px 20px 0 0",
           width: "100%",
           maxWidth: 390,
-          margin: "0 auto",
+          margin: 0,
           padding: "20px 20px 40px",
+          border: "none",
+          zIndex: 201,
+          boxSizing: "border-box",
         }}
-        onClick={(e) => e.stopPropagation()}
       >
         <div
           style={{
@@ -293,15 +304,15 @@ function AddSheet({
         >
           Guardar
         </button>
-      </div>
-    </div>
+      </dialog>
+    </>
   );
 }
 
 export default function ExpensesPage() {
   const [tab, setTab] = useState<Tab>("cuotas");
   const [showForm, setShowForm] = useState(false);
-  const [isPending, startTransition] = useTransition();
+  const [, startTransition] = useTransition();
   const queryClient = useQueryClient();
 
   const { data: member } = useCoupleMember();
@@ -312,9 +323,7 @@ export default function ExpensesPage() {
     member?.user_id ?? null,
   );
   const { data: categories = [] } = useCategories(coupleId);
-  const [filterCategory, setFilterCategory] = useState<string | null | "all">(
-    "all",
-  );
+  const [filterCategory] = useState<string | null>("all");
 
   const getInitials = (userId: string) => {
     const p = profiles.find((pr) => pr.user_id === userId);
@@ -343,8 +352,8 @@ export default function ExpensesPage() {
       if (tab === "cuotas") {
         await createInstallmentPurchase({
           description: fields.description,
-          total_amount: parseFloat(fields.total_amount),
-          installments: parseInt(fields.installments),
+          total_amount: Number.parseFloat(fields.total_amount),
+          installments: Number.parseInt(fields.installments),
           first_payment_date:
             fields.first_payment_date || new Date().toISOString().slice(0, 10),
           category_id: categoryId ?? undefined,
@@ -353,14 +362,14 @@ export default function ExpensesPage() {
       } else if (tab === "fijos") {
         await createFixedExpenseTemplate({
           description: fields.description,
-          amount: parseFloat(fields.amount),
-          due_day: parseInt(fields.due_day),
+          amount: Number.parseFloat(fields.amount),
+          due_day: Number.parseInt(fields.due_day),
           category_id: categoryId ?? undefined,
         });
       } else {
         await createVariableExpense({
           description: fields.description,
-          amount: parseFloat(fields.amount),
+          amount: Number.parseFloat(fields.amount),
           date: fields.date || new Date().toISOString().slice(0, 10),
           category_id: categoryId ?? undefined,
         });
@@ -378,14 +387,19 @@ export default function ExpensesPage() {
     filterCategory === "all"
       ? allCuotas
       : allCuotas.filter((c) => c.category_id === filterCategory);
-  const fijos = filterCategory === "all" ? allFijos : allFijos;
+  const fijos =
+    filterCategory === "all"
+      ? allFijos
+      : allFijos.filter(
+          (f) => f.fixed_expense_templates?.category_id === filterCategory,
+        );
   const variables =
     filterCategory === "all"
       ? allVariables
       : allVariables.filter((v) => v.category_id === filterCategory);
 
   return (
-    <div
+    <main
       style={{
         display: "flex",
         flexDirection: "column",
@@ -400,17 +414,18 @@ export default function ExpensesPage() {
           paddingTop: 14,
         }}
       >
-        <div
+        <h1
           style={{
             fontSize: 20,
             fontWeight: 700,
             color: "var(--fg-1)",
             fontFamily: "var(--font-sans)",
             padding: "0 20px 10px",
+            margin: 0,
           }}
         >
           Gastos
-        </div>
+        </h1>
         <SegmentedControl active={tab} onChange={setTab} />
       </div>
 
@@ -800,7 +815,7 @@ export default function ExpensesPage() {
         )}
       </div>
 
-      <FAB onClick={() => setShowForm(true)} label="Agregar gasto" />
+      <Fab onClick={() => setShowForm(true)} label="Agregar gasto" />
       {showForm && (
         <AddSheet
           tab={tab}
@@ -809,6 +824,6 @@ export default function ExpensesPage() {
           onSave={handleSave}
         />
       )}
-    </div>
+    </main>
   );
 }

--- a/src/app/(app)/history/page.tsx
+++ b/src/app/(app)/history/page.tsx
@@ -27,10 +27,10 @@ function MonthCard({
   onClick,
   hideIfEmpty = false,
 }: {
-  coupleId: string;
-  month: string;
-  onClick: () => void;
-  hideIfEmpty?: boolean;
+  readonly coupleId: string;
+  readonly month: string;
+  readonly onClick: () => void;
+  readonly hideIfEmpty?: boolean;
 }) {
   const { data, isLoading } = useMonthlyData(coupleId, month);
 
@@ -187,9 +187,9 @@ function MonthDetail({
   month,
   onBack,
 }: {
-  coupleId: string;
-  month: string;
-  onBack: () => void;
+  readonly coupleId: string;
+  readonly month: string;
+  readonly onBack: () => void;
 }) {
   const { data } = useMonthlyData(coupleId, month);
 
@@ -418,7 +418,7 @@ export default function HistoryPage() {
   }
 
   return (
-    <div
+    <main
       style={{
         display: "flex",
         flexDirection: "column",
@@ -433,16 +433,17 @@ export default function HistoryPage() {
           padding: "14px 20px",
         }}
       >
-        <div
+        <h1
           style={{
             fontSize: 20,
             fontWeight: 700,
             color: "var(--fg-1)",
             fontFamily: "var(--font-sans)",
+            margin: 0,
           }}
         >
           Historial
-        </div>
+        </h1>
       </div>
       <div
         style={{
@@ -453,7 +454,17 @@ export default function HistoryPage() {
           gap: 8,
         }}
       >
-        {!coupleId ? (
+        {coupleId ? (
+          months.map((month) => (
+            <MonthCard
+              key={month}
+              coupleId={coupleId}
+              month={month}
+              onClick={() => setSelected(month)}
+              hideIfEmpty
+            />
+          ))
+        ) : (
           <div
             style={{
               textAlign: "center",
@@ -465,18 +476,8 @@ export default function HistoryPage() {
           >
             Configurá tu pareja para ver el historial.
           </div>
-        ) : (
-          months.map((month) => (
-            <MonthCard
-              key={month}
-              coupleId={coupleId}
-              month={month}
-              onClick={() => setSelected(month)}
-              hideIfEmpty
-            />
-          ))
         )}
       </div>
-    </div>
+    </main>
   );
 }

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/lib/queries/use-monthly-data";
 import { upsertIncome } from "@/lib/actions/expenses";
 import { sendInvitation, createCouple } from "@/lib/actions/couple";
-import { formatARS, getMonthDate } from "@/lib/utils";
+import { getMonthDate } from "@/lib/utils";
 import { createClient } from "@/lib/supabase/client";
 
 function getInitials(name: string): string {
@@ -30,9 +30,28 @@ export default function SettingsPage() {
   const [isPending, startTransition] = useTransition();
   const [inviteEmail, setInviteEmail] = useState("");
   const [inviteMsg, setInviteMsg] = useState("");
+  const [inviteExpiresAt, setInviteExpiresAt] = useState<string | null>(null);
   const [myIncome, setMyIncome] = useState("");
 
   const supabase = createClient();
+
+  useEffect(() => {
+    if (!member) return;
+    // Check for existing pending invitation
+    const now = new Date().toISOString();
+    supabase
+      .from("invitations")
+      .select("expires_at")
+      .eq("couple_id", member.couple_id)
+      .is("accepted_at", null)
+      .gt("expires_at", now)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle()
+      .then(({ data }) => {
+        if (data) setInviteExpiresAt(data.expires_at);
+      });
+  }, [member, supabase]);
 
   useEffect(() => {
     if (!member) return;
@@ -49,13 +68,8 @@ export default function SettingsPage() {
       });
   }, [member, supabase]);
 
-  const myPct = (() => {
-    const v = parseInt(myIncome.replace(/\D/g, "")) || 0;
-    return v > 0 ? `${Math.round((v / (v * 1.5)) * 100)}%` : "—";
-  })();
-
   async function handleSaveIncome() {
-    const amount = parseInt(myIncome.replace(/\D/g, ""));
+    const amount = Number.parseInt(myIncome.replaceAll(/\D/g, ""));
     if (!amount || !member) return;
     startTransition(async () => {
       await upsertIncome(amount, getMonthDate());
@@ -70,12 +84,16 @@ export default function SettingsPage() {
     });
   }
 
-  async function handleInvite(e: React.FormEvent) {
+  async function handleInvite(e: React.SyntheticEvent) {
     e.preventDefault();
     if (!member || !inviteEmail) return;
     startTransition(async () => {
       try {
-        await sendInvitation(member.couple_id, inviteEmail);
+        const { expiresAt } = await sendInvitation(
+          member.couple_id,
+          inviteEmail,
+        );
+        setInviteExpiresAt(expiresAt);
         setInviteMsg("Invitación enviada ✓");
         setInviteEmail("");
       } catch (err) {
@@ -86,7 +104,7 @@ export default function SettingsPage() {
 
   async function handleSignOut() {
     await supabase.auth.signOut();
-    window.location.href = "/login";
+    globalThis.location.href = "/login";
   }
 
   if (isLoading) {
@@ -113,7 +131,7 @@ export default function SettingsPage() {
   }
 
   return (
-    <div
+    <main
       style={{
         display: "flex",
         flexDirection: "column",
@@ -128,16 +146,17 @@ export default function SettingsPage() {
           padding: "14px 20px",
         }}
       >
-        <div
+        <h1
           style={{
             fontSize: 20,
             fontWeight: 700,
             color: "var(--fg-1)",
             fontFamily: "var(--font-sans)",
+            margin: 0,
           }}
         >
           Configuración
-        </div>
+        </h1>
       </div>
 
       <div
@@ -173,43 +192,7 @@ export default function SettingsPage() {
               boxShadow: "var(--shadow-sm)",
             }}
           >
-            {!member ? (
-              <div
-                style={{
-                  padding: "20px 16px",
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: 12,
-                }}
-              >
-                <div
-                  style={{
-                    fontSize: 14,
-                    color: "var(--fg-2)",
-                    fontFamily: "var(--font-sans)",
-                  }}
-                >
-                  No tenés una pareja configurada todavía.
-                </div>
-                <button
-                  onClick={handleCreateCouple}
-                  disabled={isPending}
-                  style={{
-                    background: "var(--accent)",
-                    color: "white",
-                    border: "none",
-                    borderRadius: 10,
-                    padding: "10px 16px",
-                    fontSize: 14,
-                    fontWeight: 600,
-                    cursor: "pointer",
-                    fontFamily: "var(--font-sans)",
-                  }}
-                >
-                  Crear pareja
-                </button>
-              </div>
-            ) : (
+            {member ? (
               <>
                 <div
                   style={{
@@ -288,63 +271,130 @@ export default function SettingsPage() {
                     >
                       Invitar pareja
                     </div>
-                    <form
-                      onSubmit={handleInvite}
-                      style={{ display: "flex", gap: 8 }}
-                    >
-                      <input
-                        type="email"
-                        value={inviteEmail}
-                        onChange={(e) => setInviteEmail(e.target.value)}
-                        placeholder="email@ejemplo.com"
+                    {inviteExpiresAt &&
+                    new Date(inviteExpiresAt) > new Date() ? (
+                      <div
+                        aria-live="polite"
                         style={{
-                          flex: 1,
-                          border: "1.5px solid var(--border-default)",
+                          background: "var(--bg-sunken)",
+                          border: "1px solid var(--border-subtle)",
                           borderRadius: 10,
                           padding: "10px 12px",
-                          fontSize: 14,
-                          fontFamily: "var(--font-sans)",
-                          background: "var(--bg-elevated)",
-                          color: "var(--fg-1)",
-                          outline: "none",
-                        }}
-                      />
-                      <button
-                        type="submit"
-                        disabled={isPending || !inviteEmail}
-                        style={{
-                          background: "var(--accent)",
-                          color: "white",
-                          border: "none",
-                          borderRadius: 10,
-                          padding: "10px 14px",
                           fontSize: 13,
-                          fontWeight: 600,
-                          cursor: "pointer",
-                          fontFamily: "var(--font-sans)",
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        Invitar
-                      </button>
-                    </form>
-                    {inviteMsg && (
-                      <div
-                        style={{
-                          marginTop: 6,
-                          fontSize: 12,
-                          color: inviteMsg.includes("✓")
-                            ? "var(--status-success)"
-                            : "var(--status-danger)",
+                          color: "var(--fg-2)",
                           fontFamily: "var(--font-sans)",
                         }}
                       >
-                        {inviteMsg}
+                        ⏳ Invitación pendiente hasta el{" "}
+                        <strong>
+                          {new Date(inviteExpiresAt).toLocaleDateString(
+                            "es-AR",
+                            {
+                              day: "numeric",
+                              month: "long",
+                            },
+                          )}
+                        </strong>{" "}
+                        . Vas a poder reenviar cuando expire.
                       </div>
+                    ) : (
+                      <>
+                        <form
+                          onSubmit={handleInvite}
+                          style={{ display: "flex", gap: 8 }}
+                        >
+                          <input
+                            type="email"
+                            value={inviteEmail}
+                            onChange={(e) => setInviteEmail(e.target.value)}
+                            placeholder="email@ejemplo.com"
+                            style={{
+                              flex: 1,
+                              border: "1.5px solid var(--border-default)",
+                              borderRadius: 10,
+                              padding: "10px 12px",
+                              fontSize: 14,
+                              fontFamily: "var(--font-sans)",
+                              background: "var(--bg-elevated)",
+                              color: "var(--fg-1)",
+                              outline: "none",
+                            }}
+                          />
+                          <button
+                            type="submit"
+                            disabled={isPending || !inviteEmail}
+                            style={{
+                              background: "var(--accent)",
+                              color: "white",
+                              border: "none",
+                              borderRadius: 10,
+                              padding: "10px 14px",
+                              fontSize: 13,
+                              fontWeight: 600,
+                              cursor: "pointer",
+                              fontFamily: "var(--font-sans)",
+                              whiteSpace: "nowrap",
+                            }}
+                          >
+                            Invitar
+                          </button>
+                        </form>
+                        {inviteMsg && (
+                          <div
+                            aria-live="polite"
+                            style={{
+                              marginTop: 6,
+                              fontSize: 12,
+                              color: inviteMsg.includes("✓")
+                                ? "var(--status-success)"
+                                : "var(--status-danger)",
+                              fontFamily: "var(--font-sans)",
+                            }}
+                          >
+                            {inviteMsg}
+                          </div>
+                        )}
+                      </>
                     )}
                   </div>
                 )}
               </>
+            ) : (
+              <div
+                style={{
+                  padding: "20px 16px",
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 12,
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: 14,
+                    color: "var(--fg-2)",
+                    fontFamily: "var(--font-sans)",
+                  }}
+                >
+                  No tenés una pareja configurada todavía.
+                </div>
+                <button
+                  onClick={handleCreateCouple}
+                  disabled={isPending}
+                  style={{
+                    background: "var(--accent)",
+                    color: "white",
+                    border: "none",
+                    borderRadius: 10,
+                    padding: "10px 16px",
+                    fontSize: 14,
+                    fontWeight: 600,
+                    cursor: "pointer",
+                    fontFamily: "var(--font-sans)",
+                  }}
+                >
+                  Crear pareja
+                </button>
+              </div>
             )}
           </div>
         </section>
@@ -419,6 +469,7 @@ export default function SettingsPage() {
                 <button
                   onClick={handleSaveIncome}
                   disabled={isPending || !myIncome}
+                  aria-busy={isPending}
                   style={{
                     width: "100%",
                     background: "var(--accent)",
@@ -512,6 +563,6 @@ export default function SettingsPage() {
           </div>
         </section>
       </div>
-    </div>
+    </main>
   );
 }

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import { Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 
-export default function LoginPage() {
+function LoginContent() {
   const supabase = createClient();
   const searchParams = useSearchParams();
 
@@ -202,5 +203,13 @@ export default function LoginPage() {
         </div>
       </div>
     </main>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginContent />
+    </Suspense>
   );
 }

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,21 +1,29 @@
 "use client";
 
+import { useSearchParams } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 
 export default function LoginPage() {
   const supabase = createClient();
+  const searchParams = useSearchParams();
 
   async function signInWithGoogle() {
+    const next = searchParams.get("next");
+    const redirectPath = next?.startsWith("/") ? next : "/dashboard";
+    const redirectUrl = new URL("/auth/callback", globalThis.location.origin);
+
+    redirectUrl.searchParams.set("next", redirectPath);
+
     await supabase.auth.signInWithOAuth({
       provider: "google",
       options: {
-        redirectTo: `${window.location.origin}/auth/callback`,
+        redirectTo: redirectUrl.toString(),
       },
     });
   }
 
   return (
-    <div
+    <main
       style={{
         height: "100dvh",
         display: "flex",
@@ -67,7 +75,7 @@ export default function LoginPage() {
         </div>
 
         <div style={{ textAlign: "center" }}>
-          <div
+          <h1
             style={{
               fontSize: 28,
               fontWeight: 700,
@@ -75,10 +83,11 @@ export default function LoginPage() {
               letterSpacing: "-0.02em",
               fontFamily: "DM Sans, system-ui, sans-serif",
               lineHeight: 1.2,
+              margin: 0,
             }}
           >
             Gastos en Pareja
-          </div>
+          </h1>
           <div
             style={{
               fontSize: 15,
@@ -185,13 +194,13 @@ export default function LoginPage() {
             textAlign: "center",
             marginTop: 14,
             fontSize: 12,
-            color: "#9A9AA6",
+            color: "var(--fg-3)",
             fontFamily: "DM Sans, system-ui, sans-serif",
           }}
         >
           Al continuar aceptás los términos de uso
         </div>
       </div>
-    </div>
+    </main>
   );
 }

--- a/src/app/api/couple/member-profiles/route.ts
+++ b/src/app/api/couple/member-profiles/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+
+export async function GET() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+  }
+
+  const service = await createServiceClient();
+  const { data, error } = await service.rpc("get_couple_member_profiles", {
+    p_user_id: user.id,
+  });
+
+  if (error) {
+    return NextResponse.json(
+      { error: "No se pudieron cargar los perfiles de la pareja" },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json(data ?? []);
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,20 +6,47 @@
   /* Violet (accent / Persona A) */
   --color-violet-50: #f0eeff;
   --color-violet-100: #ddd8ff;
+  --color-violet-200: #beb4fe;
+  --color-violet-300: #9d8ffc;
+  --color-violet-400: #8b79fa;
   --color-violet-500: #6c5ce7;
   --color-violet-600: #5849d1;
+  --color-violet-700: #4438b8;
+  --color-violet-800: #342c90;
+  --color-violet-900: #231e63;
 
   /* Teal (Persona B / success) */
   --color-teal-50: #e6faf6;
+  --color-teal-100: #c0f1e7;
+  --color-teal-200: #85e3cf;
+  --color-teal-300: #40d0b4;
+  --color-teal-400: #15be9e;
   --color-teal-500: #00b894;
+  --color-teal-600: #009e7e;
+  --color-teal-700: #00836a;
+  --color-teal-800: #006652;
+  --color-teal-900: #004a3c;
 
   /* Coral (danger / deuda) */
   --color-coral-50: #fef0ed;
+  --color-coral-100: #fcddd7;
+  --color-coral-200: #f8b7ab;
+  --color-coral-300: #f2907e;
+  --color-coral-400: #eb7460;
   --color-coral-500: #e17055;
+  --color-coral-600: #c45a41;
+  --color-coral-700: #a44631;
+  --color-coral-800: #823424;
+  --color-coral-900: #5e2219;
 
   /* Amber (warning) */
   --color-amber-50: #fffbeb;
+  --color-amber-100: #fef3c7;
+  --color-amber-200: #fde68a;
+  --color-amber-300: #fcd34d;
   --color-amber-400: #fdcb6e;
+  --color-amber-500: #f59e0b;
+  --color-amber-600: #d97706;
 
   /* Neutrals */
   --color-neutral-0: #ffffff;
@@ -27,7 +54,8 @@
   --color-neutral-100: #efeff1;
   --color-neutral-200: #e2e2e6;
   --color-neutral-300: #c8c8ce;
-  --color-neutral-400: #9a9aa6;
+  --color-neutral-400: #6c6c78; /* corregido: 4.84:1 sobre bg-base ✅ WCAG AA */
+  --color-neutral-450: #9a9aa6; /* valor original — solo para dark --fg-2 */
   --color-neutral-500: #6e6e7a;
   --color-neutral-600: #4a4a56;
   --color-neutral-700: #2e2e38;
@@ -52,23 +80,29 @@
 
   --person-a: var(--color-violet-500);
   --person-a-subtle: var(--color-violet-50);
+  --person-a-fg: var(--color-neutral-0);
   --person-b: var(--color-teal-500);
   --person-b-subtle: var(--color-teal-50);
+  --person-b-fg: var(--color-neutral-0);
 
   --status-success: var(--color-teal-500);
   --status-success-subtle: var(--color-teal-50);
   --status-danger: var(--color-coral-500);
   --status-danger-subtle: var(--color-coral-50);
   --status-warning: var(--color-amber-400);
+  --status-warning-subtle: var(--color-amber-50);
   --status-pending: var(--color-neutral-400);
   --status-pending-subtle: var(--color-neutral-100);
 
   --border-subtle: rgba(0, 0, 0, 0.06);
   --border-default: var(--color-neutral-200);
+  --border-strong: var(--color-neutral-300);
   --border-focus: var(--color-violet-500);
 
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04);
   --shadow-md: 0 1px 3px rgba(0, 0, 0, 0.08), 0 4px 16px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 4px 6px rgba(0, 0, 0, 0.07), 0 12px 32px rgba(0, 0, 0, 0.1);
+  --shadow-xl: 0 8px 16px rgba(0, 0, 0, 0.08), 0 24px 48px rgba(0, 0, 0, 0.12);
 
   --radius-sm: 8px;
   --radius-md: 12px;
@@ -78,6 +112,41 @@
 
   --font-sans: "DM Sans", system-ui, -apple-system, sans-serif;
   --font-mono: "JetBrains Mono", "Courier New", monospace;
+
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-base: 16px;
+  --text-lg: 20px;
+  --text-xl: 24px;
+  --text-2xl: 32px;
+  --text-3xl: 40px;
+
+  --leading-tight: 1.2;
+  --leading-snug: 1.35;
+  --leading-normal: 1.5;
+  --leading-relaxed: 1.65;
+
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --weight-bold: 700;
+
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  --duration-fast: 100ms;
+  --duration-normal: 150ms;
+  --duration-slow: 250ms;
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
 
   --bottom-nav-height: 68px;
   --screen-padding: 16px;
@@ -90,11 +159,12 @@
     --bg-sunken: rgba(255, 255, 255, 0.05);
 
     --fg-1: var(--color-neutral-50);
-    --fg-2: var(--color-neutral-400);
+    --fg-2: var(--color-neutral-450); /* #9a9aa6 → 6.88:1 sobre dark bg ✅ */
     --fg-3: var(--color-neutral-600);
+    --fg-inverse: var(--color-neutral-900);
 
-    --accent: var(--color-violet-100);
-    --accent-hover: var(--color-violet-50);
+    --accent: var(--color-violet-400);
+    --accent-hover: var(--color-violet-300);
     --accent-subtle: rgba(108, 92, 231, 0.15);
 
     --person-a-subtle: rgba(108, 92, 231, 0.15);
@@ -102,13 +172,18 @@
 
     --status-success-subtle: rgba(0, 184, 148, 0.12);
     --status-danger-subtle: rgba(225, 112, 85, 0.12);
+    --status-warning-subtle: rgba(253, 203, 110, 0.12);
     --status-pending-subtle: rgba(255, 255, 255, 0.06);
 
     --border-subtle: rgba(255, 255, 255, 0.06);
     --border-default: rgba(255, 255, 255, 0.1);
+    --border-strong: rgba(255, 255, 255, 0.16);
 
     --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
     --shadow-md: 0 1px 3px rgba(0, 0, 0, 0.3), 0 4px 16px rgba(0, 0, 0, 0.25);
+    --shadow-lg: 0 4px 6px rgba(0, 0, 0, 0.3), 0 12px 32px rgba(0, 0, 0, 0.35);
+    --shadow-xl:
+      0 8px 16px rgba(0, 0, 0, 0.35), 0 24px 48px rgba(0, 0, 0, 0.45);
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -60,8 +60,6 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
-  maximumScale: 1,
-  userScalable: false,
   themeColor: "#6C5CE7",
 };
 

--- a/src/components/navigation/bottom-nav.tsx
+++ b/src/components/navigation/bottom-nav.tsx
@@ -85,6 +85,7 @@ export function BottomNav() {
 
   return (
     <nav
+      aria-label="Navegación principal"
       style={{
         position: "fixed",
         bottom: 0,
@@ -110,6 +111,8 @@ export function BottomNav() {
           <Link
             key={item.id}
             href={item.href}
+            aria-current={isActive ? "page" : undefined}
+            aria-label={item.label}
             style={{
               flex: 1,
               display: "flex",

--- a/src/components/shared/avatar.tsx
+++ b/src/components/shared/avatar.tsx
@@ -9,13 +9,19 @@ interface AvatarProps {
 const sizes = { sm: 28, md: 36, lg: 48, xl: 60 };
 const fonts = { sm: 10, md: 13, lg: 17, xl: 22 };
 
-export function Avatar({ initials, person, size = "md" }: AvatarProps) {
+export function Avatar({
+  initials,
+  person,
+  size = "md",
+}: Readonly<AvatarProps>) {
   const px = sizes[size];
   const fs = fonts[size];
   const bg = person === "a" ? "var(--person-a)" : "var(--person-b)";
 
   return (
     <div
+      role="img"
+      aria-label={`Avatar de ${initials}`}
       style={{
         width: px,
         height: px,

--- a/src/components/shared/category-picker.tsx
+++ b/src/components/shared/category-picker.tsx
@@ -14,12 +14,38 @@ export function CategoryPicker({
   categories,
   value,
   onChange,
-}: CategoryPickerProps) {
+}: Readonly<CategoryPickerProps>) {
   return (
-    <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+    <fieldset
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        gap: 6,
+        margin: 0,
+        padding: 0,
+        border: "none",
+        minInlineSize: 0,
+      }}
+    >
+      <legend
+        style={{
+          position: "absolute",
+          width: 1,
+          height: 1,
+          padding: 0,
+          margin: -1,
+          overflow: "hidden",
+          clip: "rect(0, 0, 0, 0)",
+          whiteSpace: "nowrap",
+          border: 0,
+        }}
+      >
+        Categoría del gasto
+      </legend>
       <button
         type="button"
         onClick={() => onChange(null)}
+        aria-pressed={value === null}
         style={{
           padding: "5px 10px",
           borderRadius: 99,
@@ -40,6 +66,7 @@ export function CategoryPicker({
           key={cat.id}
           type="button"
           onClick={() => onChange(cat.id)}
+          aria-pressed={value === cat.id}
           style={{
             padding: "5px 10px",
             borderRadius: 99,
@@ -56,9 +83,9 @@ export function CategoryPicker({
             gap: 4,
           }}
         >
-          <span>{cat.icon}</span> {cat.name}
+          <span aria-hidden="true">{cat.icon}</span> {cat.name}
         </button>
       ))}
-    </div>
+    </fieldset>
   );
 }

--- a/src/components/shared/month-header.tsx
+++ b/src/components/shared/month-header.tsx
@@ -12,7 +12,7 @@ export function MonthHeader({
   onPrev,
   onNext,
   canGoNext = true,
-}: MonthHeaderProps) {
+}: Readonly<MonthHeaderProps>) {
   return (
     <div
       style={{
@@ -41,6 +41,7 @@ export function MonthHeader({
         aria-label="Mes anterior"
       >
         <svg
+          aria-hidden="true"
           width="20"
           height="20"
           viewBox="0 0 24 24"
@@ -80,6 +81,7 @@ export function MonthHeader({
         aria-label="Mes siguiente"
       >
         <svg
+          aria-hidden="true"
           width="20"
           height="20"
           viewBox="0 0 24 24"

--- a/src/lib/actions/couple.ts
+++ b/src/lib/actions/couple.ts
@@ -11,19 +11,45 @@ export async function createCouple() {
   } = await supabase.auth.getUser();
   if (!user) throw new Error("No autenticado");
 
-  // Use SECURITY DEFINER RPC — bypasses RLS on couples table.
-  // Kong/PostgREST may not propagate ES256 JWT claims for direct table inserts,
-  // so auth.uid() can be null even with a valid session. Passing user_id explicitly.
-  const { data: coupleId, error } = await supabase.rpc(
-    "create_couple_for_user",
-    { p_user_id: user.id },
-  );
+  const service = await createServiceClient();
+  const { data: existingMember, error: existingMemberError } = await service
+    .from("couple_members")
+    .select("couple_id")
+    .eq("user_id", user.id)
+    .maybeSingle();
 
-  if (error || !coupleId)
-    throw new Error(error?.message ?? "Error al crear la pareja");
+  if (existingMemberError) {
+    throw new Error("No se pudo verificar tu pareja actual");
+  }
+
+  if (existingMember?.couple_id) {
+    revalidatePath("/", "layout");
+    return { coupleId: existingMember.couple_id };
+  }
+
+  const { data: couple, error: coupleError } = await service
+    .from("couples")
+    .insert({ status: "PENDING" })
+    .select("id")
+    .single();
+
+  if (coupleError || !couple) {
+    throw new Error("Error al crear la pareja");
+  }
+
+  const { error: memberError } = await service.from("couple_members").insert({
+    couple_id: couple.id,
+    user_id: user.id,
+    role: "OWNER",
+  });
+
+  if (memberError) {
+    await service.from("couples").delete().eq("id", couple.id);
+    throw new Error("Error al vincular tu usuario a la pareja");
+  }
 
   revalidatePath("/", "layout");
-  return { coupleId };
+  return { coupleId: couple.id };
 }
 
 export async function sendInvitation(coupleId: string, email: string) {
@@ -33,27 +59,76 @@ export async function sendInvitation(coupleId: string, email: string) {
   } = await supabase.auth.getUser();
   if (!user) throw new Error("No autenticado");
 
-  // Rate limit: máx 5 invitaciones por usuario en la última hora
-  const oneHourAgo = new Date(Date.now() - 3_600_000).toISOString();
-  const { count } = await supabase
-    .from("invitations")
-    .select("id", { count: "exact", head: true })
-    .eq("inviter_id", user.id)
-    .gte("created_at", oneHourAgo);
+  const normalizedEmail = email.trim().toLowerCase();
+  if (!normalizedEmail) throw new Error("Ingresá un email válido");
 
-  if ((count ?? 0) >= 5) {
-    throw new Error(
-      "Límite de invitaciones alcanzado. Intentá de nuevo en una hora.",
-    );
+  if (user.email?.toLowerCase() === normalizedEmail) {
+    throw new Error("No podés invitarte a vos mismo");
   }
 
-  const { data: invitation, error } = await supabase
-    .from("invitations")
-    .insert({ couple_id: coupleId, inviter_id: user.id, email })
-    .select()
-    .single();
+  const now = new Date().toISOString();
+  const { data: existingInvitation, error: existingInvitationError } =
+    await supabase
+      .from("invitations")
+      .select("*")
+      .eq("couple_id", coupleId)
+      .eq("email", normalizedEmail)
+      .is("accepted_at", null)
+      .gt("expires_at", now)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
 
-  if (error || !invitation) throw new Error("Error al crear la invitación");
+  if (existingInvitationError) {
+    throw new Error("No se pudo verificar la invitación existente");
+  }
+
+  let invitation = existingInvitation;
+  const service = await createServiceClient();
+
+  // Rate limit: máx 5 invitaciones por usuario en la última hora
+  const oneHourAgo = new Date(Date.now() - 3_600_000).toISOString();
+  if (!invitation) {
+    const { error: cleanupError } = await service
+      .from("invitations")
+      .delete()
+      .eq("couple_id", coupleId)
+      .eq("email", normalizedEmail)
+      .is("accepted_at", null)
+      .lte("expires_at", now);
+
+    if (cleanupError) {
+      throw new Error("No se pudieron limpiar invitaciones expiradas");
+    }
+
+    const { count } = await supabase
+      .from("invitations")
+      .select("id", { count: "exact", head: true })
+      .eq("inviter_id", user.id)
+      .gte("created_at", oneHourAgo);
+
+    if ((count ?? 0) >= 5) {
+      throw new Error(
+        "Límite de invitaciones alcanzado. Intentá de nuevo en una hora.",
+      );
+    }
+
+    const { data: createdInvitation, error } = await supabase
+      .from("invitations")
+      .insert({
+        couple_id: coupleId,
+        inviter_id: user.id,
+        email: normalizedEmail,
+      })
+      .select()
+      .single();
+
+    if (error || !createdInvitation) {
+      throw new Error("Error al crear la invitación");
+    }
+
+    invitation = createdInvitation;
+  }
 
   // Build invite URL from request headers — no NEXT_PUBLIC_APP_URL needed
   const { headers } = await import("next/headers");
@@ -63,7 +138,7 @@ export async function sendInvitation(coupleId: string, email: string) {
   const inviteUrl = `${proto}://${host}/invite/${invitation.token}`;
 
   await sendEmail({
-    to: email,
+    to: normalizedEmail,
     subject: `${user.email} te invitó a Gastos en Pareja`,
     html: `
       <p>Hola,</p>
@@ -73,7 +148,7 @@ export async function sendInvitation(coupleId: string, email: string) {
     `,
   });
 
-  return { token: invitation.token };
+  return { token: invitation.token, expiresAt: invitation.expires_at };
 }
 
 export async function acceptInvitation(token: string) {

--- a/src/lib/queries/use-monthly-data.ts
+++ b/src/lib/queries/use-monthly-data.ts
@@ -2,6 +2,10 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
+import type { Database } from "@/types/database";
+
+type CoupleMemberProfile =
+  Database["public"]["Functions"]["get_couple_member_profiles"]["Returns"][number];
 
 export function useMonthlyData(coupleId: string | null, month: string) {
   const supabase = createClient();
@@ -87,17 +91,18 @@ export function useCategories(coupleId: string | null) {
 }
 
 export function useCoupleMemberProfiles(userId: string | null) {
-  const supabase = createClient();
   return useQuery({
     queryKey: ["couple-member-profiles", userId],
     enabled: !!userId,
     queryFn: async () => {
       if (!userId) return [];
-      const { data, error } = await supabase.rpc("get_couple_member_profiles", {
-        p_user_id: userId,
+      const response = await fetch("/api/couple/member-profiles", {
+        cache: "no-store",
       });
-      if (error) return [];
-      return data ?? [];
+
+      if (!response.ok) return [];
+
+      return (await response.json()) as CoupleMemberProfile[];
     },
   });
 }

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,4 +1,5 @@
 import { createServerClient } from "@supabase/ssr";
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 import { cookies } from "next/headers";
 import type { Database } from "@/types/database";
 
@@ -34,24 +35,14 @@ export async function createClient() {
 }
 
 export async function createServiceClient() {
-  const cookieStore = await cookies();
   const supabaseUrl = getRequiredServerEnv("NEXT_PUBLIC_SUPABASE_URL");
   const serviceRoleKey = getRequiredServerEnv("SUPABASE_SERVICE_ROLE_KEY");
 
-  return createServerClient<Database>(supabaseUrl, serviceRoleKey, {
-    cookies: {
-      getAll() {
-        return cookieStore.getAll();
-      },
-      setAll(cookiesToSet) {
-        try {
-          cookiesToSet.forEach(({ name, value, options }) =>
-            cookieStore.set(name, value, options),
-          );
-        } catch {
-          // noop on Server Component context
-        }
-      },
+  return createSupabaseClient<Database>(supabaseUrl, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
     },
   });
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,8 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 
+const PUBLIC_FILE_PATH = /\.[^/]+$/;
+
 function getRequiredEnv(
   name: "NEXT_PUBLIC_SUPABASE_URL" | "NEXT_PUBLIC_SUPABASE_ANON_KEY",
 ): string {
@@ -39,10 +41,20 @@ export async function proxy(request: NextRequest) {
   } = await supabase.auth.getUser();
 
   const isAuthRoute = request.nextUrl.pathname.startsWith("/login");
+  const isAuthCallbackRoute =
+    request.nextUrl.pathname.startsWith("/auth/callback");
   const isInviteRoute = request.nextUrl.pathname.startsWith("/invite");
   const isApiRoute = request.nextUrl.pathname.startsWith("/api");
+  const isPublicFileRoute = PUBLIC_FILE_PATH.test(request.nextUrl.pathname);
 
-  if (!user && !isAuthRoute && !isInviteRoute && !isApiRoute) {
+  if (
+    !user &&
+    !isAuthRoute &&
+    !isAuthCallbackRoute &&
+    !isInviteRoute &&
+    !isApiRoute &&
+    !isPublicFileRoute
+  ) {
     const url = request.nextUrl.clone();
     url.pathname = "/login";
     return NextResponse.redirect(url);
@@ -51,6 +63,7 @@ export async function proxy(request: NextRequest) {
   if (user && isAuthRoute) {
     const url = request.nextUrl.clone();
     url.pathname = "/dashboard";
+    url.search = "";
     return NextResponse.redirect(url);
   }
 
@@ -59,6 +72,6 @@ export async function proxy(request: NextRequest) {
 
 export const config = {
   matcher: [
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+    "/((?!_next/static|_next/image|favicon.ico|.*[.](?:svg|png|jpg|jpeg|gif|webp)$).*)",
   ],
 };

--- a/supabase/migrations/20260502123147_dedupe_pending_invitations.sql
+++ b/supabase/migrations/20260502123147_dedupe_pending_invitations.sql
@@ -1,0 +1,17 @@
+-- Remove duplicate pending invitations without touching accepted ones.
+-- Keep the newest pending row per couple/email pair and delete older duplicates.
+
+with ranked_pending_invitations as (
+	select
+		id,
+		row_number() over (
+			partition by couple_id, lower(email)
+			order by created_at desc, id desc
+		) as duplicate_rank
+	from public.invitations
+	where accepted_at is null
+)
+delete from public.invitations invitations_to_delete
+using ranked_pending_invitations ranked
+where invitations_to_delete.id = ranked.id
+	and ranked.duplicate_rank > 1;

--- a/supabase/migrations/20260502123431_enforce_unique_pending_invitations.sql
+++ b/supabase/migrations/20260502123431_enforce_unique_pending_invitations.sql
@@ -1,0 +1,6 @@
+-- Enforce at most one pending invitation per couple/email.
+-- Accepted invitations are excluded from this constraint.
+
+create unique index if not exists invitations_one_pending_per_couple_email_idx
+	on public.invitations (couple_id, lower(email))
+	where accepted_at is null;

--- a/supabase/migrations/20260502123500_harden_couple_functions.sql
+++ b/supabase/migrations/20260502123500_harden_couple_functions.sql
@@ -1,0 +1,47 @@
+-- Keep SECURITY DEFINER helpers off the public Data API surface.
+-- Client code now uses server-side access for couple creation and profile lookup.
+-- NOTE: is_couple_member() is still referenced by several RLS policies and
+-- cannot be dropped until those policies are migrated off it.
+
+drop policy if exists "couples: read own" on public.couples;
+create policy "couples: read own" on public.couples
+  for select using (
+    exists (
+      select 1
+      from public.couple_members cm
+      where cm.couple_id = public.couples.id
+        and cm.user_id = (select auth.uid())
+    )
+  );
+
+drop policy if exists "couple_members: read own couple" on public.couple_members;
+create policy "couple_members: read own couple" on public.couple_members
+  for select using (
+    exists (
+      select 1
+      from public.couple_members self_member
+      where self_member.couple_id = public.couple_members.couple_id
+        and self_member.user_id = (select auth.uid())
+    )
+  );
+
+drop policy if exists "invitations: owner can create" on public.invitations;
+create policy "invitations: owner can create" on public.invitations
+  for insert with check (
+    inviter_id = (select auth.uid())
+    and exists (
+      select 1
+      from public.couple_members cm
+      where cm.couple_id = public.invitations.couple_id
+        and cm.user_id = (select auth.uid())
+    )
+  );
+
+revoke execute on function public.create_couple_for_user(uuid) from public;
+revoke execute on function public.create_couple_for_user(uuid) from anon;
+revoke execute on function public.create_couple_for_user(uuid) from authenticated;
+
+revoke execute on function public.get_couple_member_profiles(uuid) from public;
+revoke execute on function public.get_couple_member_profiles(uuid) from anon;
+revoke execute on function public.get_couple_member_profiles(uuid) from authenticated;
+grant execute on function public.get_couple_member_profiles(uuid) to service_role;

--- a/supabase/migrations/20260502124411_inline_is_couple_member_policies.sql
+++ b/supabase/migrations/20260502124411_inline_is_couple_member_policies.sql
@@ -1,0 +1,132 @@
+-- Replace RLS policies that depend on is_couple_member() with inline EXISTS checks.
+-- This allows removing the SECURITY DEFINER helper function from the public API surface.
+
+drop policy if exists "incomes: couple members" on public.incomes;
+create policy "incomes: couple members" on public.incomes
+	for all
+	using (
+		exists (
+			select 1
+			from public.couple_members cm
+			where cm.couple_id = public.incomes.couple_id
+				and cm.user_id = (select auth.uid())
+		)
+	)
+	with check (
+		exists (
+			select 1
+			from public.couple_members cm
+			where cm.couple_id = public.incomes.couple_id
+				and cm.user_id = (select auth.uid())
+		)
+	);
+
+drop policy if exists "installment_purchases: couple members" on public.installment_purchases;
+create policy "installment_purchases: couple members" on public.installment_purchases
+	for all
+	using (
+		exists (
+			select 1
+			from public.couple_members cm
+			where cm.couple_id = public.installment_purchases.couple_id
+				and cm.user_id = (select auth.uid())
+		)
+	)
+	with check (
+		exists (
+			select 1
+			from public.couple_members cm
+			where cm.couple_id = public.installment_purchases.couple_id
+				and cm.user_id = (select auth.uid())
+		)
+	);
+
+drop policy if exists "fixed_expense_templates: couple members" on public.fixed_expense_templates;
+create policy "fixed_expense_templates: couple members" on public.fixed_expense_templates
+	for all
+	using (
+		exists (
+			select 1
+			from public.couple_members cm
+			where cm.couple_id = public.fixed_expense_templates.couple_id
+				and cm.user_id = (select auth.uid())
+		)
+	)
+	with check (
+		exists (
+			select 1
+			from public.couple_members cm
+			where cm.couple_id = public.fixed_expense_templates.couple_id
+				and cm.user_id = (select auth.uid())
+		)
+	);
+
+drop policy if exists "fixed_expense_instances: couple members" on public.fixed_expense_instances;
+create policy "fixed_expense_instances: couple members" on public.fixed_expense_instances
+	for all
+	using (
+		exists (
+			select 1
+			from public.couple_members cm
+			where cm.couple_id = public.fixed_expense_instances.couple_id
+				and cm.user_id = (select auth.uid())
+		)
+	)
+	with check (
+		exists (
+			select 1
+			from public.couple_members cm
+			where cm.couple_id = public.fixed_expense_instances.couple_id
+				and cm.user_id = (select auth.uid())
+		)
+	);
+
+drop policy if exists "variable_expenses: couple members" on public.variable_expenses;
+create policy "variable_expenses: couple members" on public.variable_expenses
+	for all
+	using (
+		exists (
+			select 1
+			from public.couple_members cm
+			where cm.couple_id = public.variable_expenses.couple_id
+				and cm.user_id = (select auth.uid())
+		)
+	)
+	with check (
+		exists (
+			select 1
+			from public.couple_members cm
+			where cm.couple_id = public.variable_expenses.couple_id
+				and cm.user_id = (select auth.uid())
+		)
+	);
+
+drop policy if exists "categories: read sistema y propia pareja" on public.expense_categories;
+create policy "categories: read sistema y propia pareja" on public.expense_categories
+	for select using (
+		public.expense_categories.couple_id is null
+		or exists (
+			select 1
+			from public.couple_members cm
+			where cm.couple_id = public.expense_categories.couple_id
+				and cm.user_id = (select auth.uid())
+		)
+	);
+
+drop policy if exists "categories: pareja puede crear propias" on public.expense_categories;
+create policy "categories: pareja puede crear propias" on public.expense_categories
+	for insert with check (
+		public.expense_categories.couple_id is not null
+		and exists (
+			select 1
+			from public.couple_members cm
+			where cm.couple_id = public.expense_categories.couple_id
+				and cm.user_id = (select auth.uid())
+		)
+	);
+
+revoke execute on function public.is_couple_member(uuid) from public;
+revoke execute on function public.is_couple_member(uuid) from anon;
+revoke execute on function public.is_couple_member(uuid) from authenticated;
+
+drop function if exists public.is_couple_member(uuid);

--- a/supabase/migrations/20260502124648_add_missing_fk_category_indexes.sql
+++ b/supabase/migrations/20260502124648_add_missing_fk_category_indexes.sql
@@ -1,0 +1,8 @@
+create index if not exists fixed_expense_templates_category_id_idx
+	on public.fixed_expense_templates (category_id);
+
+create index if not exists installment_purchases_category_id_idx
+	on public.installment_purchases (category_id);
+
+create index if not exists variable_expenses_category_id_idx
+	on public.variable_expenses (category_id);


### PR DESCRIPTION
## Summary

This release aggregates 9 bug fixes, a security hardening pass, a new UX feature, and a lint cleanup pass.

---

### Fixes included

- **#59** — `fix(proxy)`: Exclude `/auth/callback`, `/invite/*`, and static assets from auth guard to prevent OAuth redirect loops and asset MIME errors
- **#60** — `fix(security)`: Harden `SECURITY DEFINER` functions, inline `is_couple_member` in all RLS policies, add missing FK indexes
- **#61** — `fix(invitations)`: Deduplicate pending invitations, enforce unique constraint, rate-limit to 5/hour
- **#62** — `fix(security)`: Move `get_couple_member_profiles` RPC call to a server-side API route (was leaking via browser client)
- **#63** — `fix(a11y)`: Replace `<div role="group">` with semantic `<fieldset>` + visually-hidden `<legend>` in `CategoryPicker`
- **#64** — `fix(supabase)`: `createServiceClient()` uses admin client with `service_role` key — no user session cookies
- **#65** — `fix(auth)`: Pass `?next=` query param through OAuth redirect for unauthenticated invite acceptance flow

### Features included

- **#66** — `feat(settings)`: Show "invite sent" confirmation banner with expiry date; block resend until invitation expires

### Chores included

- **#67** — `chore`: Fix biome/eslint warnings across app pages and components

---

### Branch structure

Each issue has its own branch (`fix/59`, `fix/60`, ..., `feat/66`, `chore/67`), all merged `--no-ff` into `release/v1.5.0`.

Closes #59, #60, #61, #62, #63, #64, #65, #66, #67