### PR TITLE
fix: app-level bugs found during E2E test coverage

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -172,7 +172,7 @@ function BalanceCard({
           padding: "20px 20px 16px",
         }}
       >
-        <div
+        <h2
           style={{
             fontSize: 11,
             fontWeight: 600,
@@ -181,10 +181,11 @@ function BalanceCard({
             letterSpacing: "0.05em",
             marginBottom: 4,
             fontFamily: "var(--font-sans)",
+            margin: 0,
           }}
         >
           Balance {formatMonth(month)}
-        </div>
+        </h2>
         {balance.debtAmount > 0 ? (
           <>
             <div

--- a/src/app/(app)/expenses/page.tsx
+++ b/src/app/(app)/expenses/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useEffect, useTransition } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Avatar } from "@/components/shared/avatar";
 import { Badge } from "@/components/shared/badge";
@@ -94,6 +94,15 @@ function AddSheet({
   const [fields, setFields] = useState<Record<string, string>>({});
   const [categoryId, setCategoryId] = useState<string | null>(null);
   const [autoRenew, setAutoRenew] = useState(false);
+
+  // Close on Escape — <dialog open> (not showModal) doesn't handle it natively
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
 
   const fieldDefs: Record<
     Tab,
@@ -190,6 +199,7 @@ function AddSheet({
               {f.label}
             </div>
             <input
+              aria-label={f.label}
               value={fields[f.key] ?? ""}
               onChange={(e) =>
                 setFields((p) => ({ ...p, [f.key]: e.target.value }))

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -31,7 +31,7 @@ function LoginContent() {
         flexDirection: "column",
         alignItems: "center",
         justifyContent: "space-between",
-        background: "#F7F7F8",
+        background: "var(--bg-base)",
         padding: "60px 32px 48px",
         maxWidth: 390,
         margin: "0 auto",
@@ -53,19 +53,21 @@ function LoginContent() {
             width: 80,
             height: 80,
             borderRadius: 24,
-            background: "linear-gradient(135deg, #6C5CE7 0%, #8B79FA 100%)",
+            background:
+              "linear-gradient(135deg, var(--color-violet-500) 0%, var(--color-violet-400) 100%)",
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
-            boxShadow: "0 8px 32px rgba(108,92,231,0.35)",
+            boxShadow: "var(--shadow-lg)",
           }}
         >
           <svg
+            aria-hidden="true"
             width="40"
             height="40"
             viewBox="0 0 24 24"
             fill="none"
-            stroke="white"
+            stroke="var(--fg-inverse)"
             strokeWidth="1.5"
           >
             <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
@@ -80,9 +82,9 @@ function LoginContent() {
             style={{
               fontSize: 28,
               fontWeight: 700,
-              color: "#0F0F11",
+              color: "var(--fg-1)",
               letterSpacing: "-0.02em",
-              fontFamily: "DM Sans, system-ui, sans-serif",
+              fontFamily: "var(--font-sans)",
               lineHeight: 1.2,
               margin: 0,
             }}
@@ -92,10 +94,10 @@ function LoginContent() {
           <div
             style={{
               fontSize: 15,
-              color: "#6E6E7A",
+              color: "var(--fg-2)",
               marginTop: 8,
               lineHeight: 1.5,
-              fontFamily: "DM Sans, system-ui, sans-serif",
+              fontFamily: "var(--font-sans)",
             }}
           >
             Gestioná los gastos del mes
@@ -105,13 +107,17 @@ function LoginContent() {
         </div>
 
         {/* Feature pills */}
-        <div
+        <ul
+          aria-label="Características"
           style={{
             display: "flex",
             flexDirection: "column",
             gap: 10,
             marginTop: 16,
             width: "100%",
+            listStyle: "none",
+            margin: "16px 0 0",
+            padding: 0,
           }}
         >
           {[
@@ -119,43 +125,44 @@ function LoginContent() {
             { icon: "📅", text: "Control de cuotas y gastos fijos" },
             { icon: "🔄", text: "Sincronizado entre los dos" },
           ].map((f) => (
-            <div
+            <li
               key={f.text}
               style={{
-                background: "white",
+                background: "var(--bg-elevated)",
                 borderRadius: 12,
-                border: "1px solid rgba(0,0,0,0.06)",
+                border: "1px solid var(--border-subtle)",
                 padding: "12px 16px",
                 display: "flex",
                 alignItems: "center",
                 gap: 12,
-                boxShadow: "0 1px 3px rgba(0,0,0,0.06)",
+                boxShadow: "var(--shadow-sm)",
               }}
             >
               <span style={{ fontSize: 18 }}>{f.icon}</span>
               <span
                 style={{
                   fontSize: 14,
-                  color: "#4A4A56",
-                  fontFamily: "DM Sans, system-ui, sans-serif",
+                  color: "var(--fg-2)",
+                  fontFamily: "var(--font-sans)",
                   fontWeight: 500,
                 }}
               >
                 {f.text}
               </span>
-            </div>
+            </li>
           ))}
-        </div>
+        </ul>
       </div>
 
       {/* CTA */}
       <div style={{ width: "100%" }}>
         <button
+          type="button"
           onClick={signInWithGoogle}
           style={{
             width: "100%",
-            background: "white",
-            border: "1.5px solid #E2E2E6",
+            background: "var(--bg-elevated)",
+            border: "1.5px solid var(--border-default)",
             borderRadius: 14,
             padding: "16px 20px",
             display: "flex",
@@ -163,14 +170,14 @@ function LoginContent() {
             justifyContent: "center",
             gap: 12,
             cursor: "pointer",
-            boxShadow: "0 2px 8px rgba(0,0,0,0.08)",
-            fontFamily: "DM Sans, system-ui, sans-serif",
+            boxShadow: "var(--shadow-sm)",
+            fontFamily: "var(--font-sans)",
             fontSize: 16,
             fontWeight: 600,
-            color: "#1A1A20",
+            color: "var(--fg-1)",
           }}
         >
-          <svg width="22" height="22" viewBox="0 0 24 24">
+          <svg aria-hidden="true" width="22" height="22" viewBox="0 0 24 24">
             <path
               d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
               fill="#4285F4"
@@ -196,7 +203,7 @@ function LoginContent() {
             marginTop: 14,
             fontSize: 12,
             color: "var(--fg-3)",
-            fontFamily: "DM Sans, system-ui, sans-serif",
+            fontFamily: "var(--font-sans)",
           }}
         >
           Al continuar aceptás los términos de uso

--- a/src/app/auth/callback/route.test.ts
+++ b/src/app/auth/callback/route.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { getSafeNextPath } from "./route";
+
+describe("getSafeNextPath", () => {
+  it("retorna /dashboard cuando next es null", () => {
+    expect(getSafeNextPath(null)).toBe("/dashboard");
+  });
+
+  it("retorna /dashboard cuando next es una URL externa", () => {
+    expect(getSafeNextPath("https://evil.example")).toBe("/dashboard");
+  });
+
+  it("retorna /dashboard cuando next no empieza con /", () => {
+    expect(getSafeNextPath("dashboard")).toBe("/dashboard");
+  });
+
+  it("retorna /dashboard cuando next es protocol-relative", () => {
+    expect(getSafeNextPath("//evil.example")).toBe("/dashboard");
+  });
+
+  it("retorna /dashboard cuando next contiene backslashes", () => {
+    expect(getSafeNextPath(String.raw`/\evil`)).toBe("/dashboard");
+  });
+
+  it("retorna /dashboard cuando next contiene salto de línea", () => {
+    expect(getSafeNextPath("/dashboard\nheader-injection")).toBe("/dashboard");
+  });
+
+  it("permite rutas internas absolutas", () => {
+    expect(getSafeNextPath("/invite/token-123")).toBe("/invite/token-123");
+  });
+
+  it("recorta espacios alrededor de una ruta válida", () => {
+    expect(getSafeNextPath("   /dashboard   ")).toBe("/dashboard");
+  });
+
+  it("retorna /dashboard cuando next solo tiene espacios", () => {
+    expect(getSafeNextPath("   ")).toBe("/dashboard");
+  });
+});

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -3,10 +3,25 @@ import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
+export function getSafeNextPath(rawNext: string | null): string {
+  const next = rawNext?.trim() ?? "";
+  if (
+    !next ||
+    !next.startsWith("/") ||
+    next.startsWith("//") ||
+    next.includes("\\") ||
+    next.includes("\r") ||
+    next.includes("\n")
+  ) {
+    return "/dashboard";
+  }
+  return next;
+}
+
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
-  const next = searchParams.get("next") ?? "/dashboard";
+  const next = getSafeNextPath(searchParams.get("next"));
 
   if (code) {
     const cookieStore = await cookies();

--- a/src/components/shared/month-header.tsx
+++ b/src/components/shared/month-header.tsx
@@ -53,6 +53,7 @@ export function MonthHeader({
         </svg>
       </button>
       <span
+        data-testid="current-month"
         style={{
           fontSize: 17,
           fontWeight: 600,

--- a/src/lib/actions/expenses.ts
+++ b/src/lib/actions/expenses.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createClient } from "@/lib/supabase/server";
+import { getMonthDate } from "@/lib/utils";
 import { revalidatePath } from "next/cache";
 
 async function getCouple() {
@@ -109,9 +110,21 @@ export async function createFixedExpenseTemplate(data: {
   category_id?: string;
 }) {
   const { supabase, coupleId } = await getCouple();
-  await supabase
+  const { data: template, error } = await supabase
     .from("fixed_expense_templates")
-    .insert({ ...data, couple_id: coupleId });
+    .insert({ ...data, couple_id: coupleId })
+    .select("id")
+    .single();
+  if (!error && template) {
+    // Create an instance for the current month so it appears in the list immediately
+    const month = getMonthDate();
+    await supabase.from("fixed_expense_instances").insert({
+      template_id: template.id,
+      couple_id: coupleId,
+      month,
+      paid: false,
+    });
+  }
   revalidatePath("/expenses");
   revalidatePath("/dashboard");
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -56,7 +56,12 @@ export async function proxy(request: NextRequest) {
     !isPublicFileRoute
   ) {
     const url = request.nextUrl.clone();
+    const next =
+      request.nextUrl.pathname +
+      (request.nextUrl.search ? request.nextUrl.search : "");
     url.pathname = "/login";
+    url.search = "";
+    url.searchParams.set("next", next);
     return NextResponse.redirect(url);
   }
 


### PR DESCRIPTION
Closes #70

## Cambios

### Seguridad
- `auth/callback/route.ts`: extrae `getSafeNextPath()` que sanitiza el parámetro `?next=` para prevenir open redirect. Solo acepta paths internos (comienza con `/`, no con `//` ni protocolo).
- `proxy.ts`: ahora appends `?next={pathname}` al redirigir usuarios no autenticados para que el redirect post-login funcione correctamente.
- `src/app/auth/callback/route.test.ts`: 9 casos de test unitarios para `getSafeNextPath()`.

### Accesibilidad y semántica HTML
- `login/page.tsx`: feature pills convertidos de `<div>` sueltos a `<ul aria-label="Características"><li>`.
- `dashboard/page.tsx`: label de balance cambiado de `<div>` a `<h2>` para jerarquía correcta de headings.
- `month-header.tsx`: agrega `data-testid="current-month"` para detección E2E.

### Funcionalidad
- `expenses/page.tsx`: agrega handler `keydown` a nivel documento en `AddSheet` para cerrar con Escape. `<dialog open>` no maneja Escape nativo — solo `.showModal()` lo hace.
- `expenses.ts` (action): `createFixedExpenseTemplate` ahora también inserta un registro en `fixed_expense_instances` para el mes actual, así el ítem aparece inmediatamente en la pestaña Fijos.