### PR TITLE
ci: add coverage thresholds and run test:coverage in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ e2e/auth.json
 *.zip
 "Gastos en Pareja Design System*"
 
+# local design system / AI-generated scratch work
+/docs/
+
 # debug
 npm-debug.log*
 yarn-debug.log*

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,7 +12,19 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Generated files — never lint these:
+    "public/sw.js",
+    "coverage/**",
   ]),
+  // Allow _ prefix to mark intentionally unused variables
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+    },
+  },
   // E2E test files — disable React-specific rules that don't apply to Playwright
   {
     files: ["e2e/**/*.ts"],

--- a/src/app/(app)/history/page.tsx
+++ b/src/app/(app)/history/page.tsx
@@ -12,7 +12,7 @@ import { subMonths } from "date-fns";
 
 const MONTHS_TO_SHOW = 6;
 
-function useHistoryMonths(coupleId: string | null) {
+function useHistoryMonths(_coupleId: string | null) {
   const today = new Date();
   // Generate last N months (excluding current)
   return Array.from({ length: MONTHS_TO_SHOW }, (_, i) => {

--- a/src/app/auth/callback/route.test.ts
+++ b/src/app/auth/callback/route.test.ts
@@ -1,5 +1,39 @@
-import { describe, expect, it } from "vitest";
-import { getSafeNextPath } from "./route";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+// ── MOCKS ───────────────────────────────────────────────────
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(),
+}));
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(),
+}));
+
+vi.mock("next/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("next/server")>();
+  return {
+    ...actual,
+    NextResponse: {
+      redirect: vi.fn((url: URL | string) => ({
+        redirected: true,
+        url: url.toString(),
+      })),
+    },
+  };
+});
+
+import { cookies } from "next/headers";
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse } from "next/server";
+import { GET, getSafeNextPath } from "./route";
+
+// ── HELPERS ─────────────────────────────────────────────────
+function makeRequest(url: string) {
+  return { url } as NextRequest;
+}
+
+const BASE = "http://localhost:3000";
 
 describe("getSafeNextPath", () => {
   it("retorna /dashboard cuando next es null", () => {
@@ -36,5 +70,63 @@ describe("getSafeNextPath", () => {
 
   it("retorna /dashboard cuando next solo tiene espacios", () => {
     expect(getSafeNextPath("   ")).toBe("/dashboard");
+  });
+});
+
+// ── GET ──────────────────────────────────────────────────────
+describe("GET", () => {
+  const mockExchangeCodeForSession = vi.fn();
+  const mockCookieStore = { getAll: vi.fn().mockReturnValue([]), set: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(cookies).mockResolvedValue(mockCookieStore as never);
+    vi.mocked(createServerClient).mockReturnValue({
+      auth: { exchangeCodeForSession: mockExchangeCodeForSession },
+    } as never);
+  });
+
+  it("redirige a next cuando el code exchange es exitoso", async () => {
+    mockExchangeCodeForSession.mockResolvedValue({ error: null });
+    const req = makeRequest(
+      `${BASE}/auth/callback?code=abc123&next=/dashboard`,
+    );
+
+    await GET(req);
+
+    expect(NextResponse.redirect).toHaveBeenCalledWith(`${BASE}/dashboard`);
+  });
+
+  it("redirige a /dashboard por defecto cuando next no está presente", async () => {
+    mockExchangeCodeForSession.mockResolvedValue({ error: null });
+    const req = makeRequest(`${BASE}/auth/callback?code=abc123`);
+
+    await GET(req);
+
+    expect(NextResponse.redirect).toHaveBeenCalledWith(`${BASE}/dashboard`);
+  });
+
+  it("redirige a /login?error=auth_failed cuando el exchange falla", async () => {
+    mockExchangeCodeForSession.mockResolvedValue({
+      error: new Error("invalid"),
+    });
+    const req = makeRequest(`${BASE}/auth/callback?code=abc123`);
+
+    await GET(req);
+
+    expect(NextResponse.redirect).toHaveBeenCalledWith(
+      `${BASE}/login?error=auth_failed`,
+    );
+  });
+
+  it("redirige a /login?error=auth_failed cuando no hay code", async () => {
+    const req = makeRequest(`${BASE}/auth/callback`);
+
+    await GET(req);
+
+    expect(NextResponse.redirect).toHaveBeenCalledWith(
+      `${BASE}/login?error=auth_failed`,
+    );
+    expect(createServerClient).not.toHaveBeenCalled();
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,11 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 70,
+      },
     },
   },
   resolve: {


### PR DESCRIPTION
Closes #75

## Cambios

### Thresholds en `vitest.config.ts`
```
lines:     80%
functions: 80%
branches:  70%
```
Si la cobertura baja de estos valores, `vitest run --coverage` falla con exit code 1 — el CI lo detecta automáticamente.

### CI corre `test:coverage` en lugar de `test`
- El job `quality` ahora ejecuta `npm run test:coverage`
- Los thresholds se aplican en cada PR — cobertura baja = build roto

> Esta branch está rebased sobre `ci/split-jobs-fix-supabase-cli` (#77), por lo que incluye los jobs separados y el CLI fijado.