### PR TITLE
fix(ci): export SUPABASE_SERVICE_ROLE_KEY for Next.js WebServer in E2E job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
           source <(supabase status -o env)
           echo "NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321" >> $GITHUB_ENV
           echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=$ANON_KEY"         >> $GITHUB_ENV
+          echo "SUPABASE_SERVICE_ROLE_KEY=$SERVICE_ROLE_KEY"      >> $GITHUB_ENV
           echo "E2E_SUPABASE_SERVICE_KEY=$SERVICE_ROLE_KEY"       >> $GITHUB_ENV
 
       - name: Create E2E test user


### PR DESCRIPTION
## Problem

The E2E CI job was spamming `[WebServer]` errors:

```
Error: Missing required environment variable: SUPABASE_SERVICE_ROLE_KEY
    at getRequiredServerEnv (src/lib/supabase/server.ts:9:11)
    at createServiceClient (src/lib/supabase/server.ts:39:26)
    at GET (src/app/api/couple/member-profiles/route.ts:14:44)
```

The `GET /api/couple/member-profiles` route calls `createServiceClient()` which requires `SUPABASE_SERVICE_ROLE_KEY` in the Next.js process. The CI was only exporting this key as `E2E_SUPABASE_SERVICE_KEY` (for the Playwright global-setup), so the WebServer never had it.

## Fix

Added `SUPABASE_SERVICE_ROLE_KEY=$SERVICE_ROLE_KEY` to the `$GITHUB_ENV` export step, alongside the existing vars.

Tests still passed (33/33) because the affected endpoint wasn't exercised by current E2E specs, but this would cause failures in any future test that hits that route.