### PR TITLE
fix(couple): handle duplicate memberships when checking current couple

### DIFF
--- a/src/lib/actions/couple.ts
+++ b/src/lib/actions/couple.ts
@@ -16,6 +16,8 @@ export async function createCouple() {
     .from("couple_members")
     .select("couple_id")
     .eq("user_id", user.id)
+    .order("joined_at", { ascending: false })
+    .limit(1)
     .maybeSingle();
 
   if (existingMemberError) {


### PR DESCRIPTION
Fixes production error when checking current couple membership for users with duplicate rows. Uses deterministic lookup ordered by joined_at and limited to one result. Closes #83.