### PR TITLE
ci: trigger CI on push to release-please branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - "release-please--**"
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - "release-please--**"
 
 concurrency:
   group: sonarqube-${{ github.ref }}


### PR DESCRIPTION
## Problem

PR #91 (release-please `chore(master): release gastos-en-pareja 1.6.0`) is blocked because its required CI checks never run.

**Root cause**: GitHub intentionally prevents workflows triggered by `pull_request` from running when the PR is opened by `GITHUB_TOKEN` (release-please). This is an anti-recursion design decision by GitHub — it cannot be overridden without switching to a PAT or GitHub App token.

## Solution

Add `release-please--**` to the `push` trigger in both `ci.yml` and `sonarqube.yml`.

When release-please creates/updates its branch, GitHub fires a `push` event (not blocked). The commit SHA on the branch is the same SHA referenced by the PR's HEAD — so branch protection accepts push-triggered checks as satisfying the required status checks.

## Changes

- `.github/workflows/ci.yml`: added `- "release-please--**"` under `push.branches`
- `.github/workflows/sonarqube.yml`: same

## Flow after merge

1. This PR merges → master updated → release-please runs → updates `release-please--branches--master--components--gastos-en-pareja`
2. That push triggers CI on `release-please--**`
3. PR #91 gets its required checks (Lint, Unit, A11y, E2E, SonarQube) ✅
4. PR #91 can be merged → v1.6.0 released