### PR TITLE
ci: use PAT for release-please to allow workflow triggers

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Problem

PR #91 (release-please) is blocked because its required CI checks never run.

**Root cause**: GitHub uses `GITHUB_TOKEN` internally for release-please, which triggers branch pushes that GitHub's anti-recursion system blocks from firing CI workflows — even on `push` events, not just `pull_request`.

## Solution

Replace `GITHUB_TOKEN` with `RELEASE_PLEASE_TOKEN` (a fine-grained PAT with `contents: write` + `pull-requests: write`). Pushes made by a PAT ARE treated as user-initiated and DO trigger workflows normally.

## Flow after merge

1. This PR merges → master updated → release-please runs with PAT
2. PAT push to `release-please--**` branch → CI triggers normally  
3. PR #91 gets all required checks (Lint, Unit, A11y, E2E, SonarQube) ✅
4. PR #91 merges → v1.6.0 released 🎉