### PR TITLE
ci: remove release-please branch from push trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - "release-please--**"
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - "release-please--**"
 
 concurrency:
   group: sonarqube-${{ github.ref }}


### PR DESCRIPTION
## Problem

Running CI on \push\ to \elease-please--**\ branches was a workaround introduced before switching to a PAT. It caused two simultaneous SonarQube analyses for the same SHA — a race condition where one scan uploaded the report and the second failed with \Project not found\ because SonarCloud was still processing the first.

## Root cause

\ci.yml\ and \sonarqube.yml\ both had \elease-please--**\ in their push triggers (added in #92). Once the PAT was introduced in #93, the \pull_request\ event already fires correctly for the release-please PR — making the push trigger redundant.

## Fix

Remove \elease-please--**\ from push triggers in both workflows. CI now runs:
- On \pull_request\ → covers the release-please PR (works with PAT) ✓
- On \push\ to \master\ → post-merge validation ✓

No duplicate runs, no race conditions.