### PR TITLE
feat: monthly review confirmation for recurring fixed expenses

### DIFF
--- a/e2e/expenses.spec.ts
+++ b/e2e/expenses.spec.ts
@@ -365,12 +365,12 @@ test.describe("Gasto fijo — total del footer refleja overrides", () => {
         DESC_A,
     );
 
-    if (instanceA) {
-      await adminClient
-        .from("fixed_expense_instances")
-        .update({ amount_override: 30000 })
-        .eq("id", instanceA.id);
-    }
+    expect(instanceA, "instance for DESC_A not found — join failed or template insert did not create instance").toBeDefined();
+
+    await adminClient
+      .from("fixed_expense_instances")
+      .update({ amount_override: 30000 })
+      .eq("id", instanceA!.id);
 
     // Reload and check footer: should show 30000 + 20000 = 50000
     await page.reload();
@@ -382,8 +382,8 @@ test.describe("Gasto fijo — total del footer refleja overrides", () => {
     await expect(page.getByText("Total servicios")).toBeVisible({
       timeout: 10_000,
     });
-    await expect(page.getByText("$50.000").first()).toBeVisible({
-      timeout: 5_000,
+    await expect(page.getByTestId("fijos-total")).toHaveText("$50.000", {
+      timeout: 8_000,
     });
   });
 });

--- a/e2e/expenses.spec.ts
+++ b/e2e/expenses.spec.ts
@@ -367,24 +367,27 @@ test.describe("Gasto fijo — total del footer refleja overrides", () => {
 
     expect(instanceA, "instance for DESC_A not found — join failed or template insert did not create instance").toBeDefined();
 
+    // Record baseline total before override
+    await expenses.goto();
+    await expenses.selectTab("Servicios");
+    await page.waitForLoadState("networkidle", { timeout: 10_000 });
+    await expect(page.getByText("Total servicios")).toBeVisible({ timeout: 10_000 });
+    const baselineText = await page.getByTestId("fijos-total").innerText();
+    const baseline = Number(baselineText.replace(/[^0-9]/g, ""));
+
     await adminClient
       .from("fixed_expense_instances")
       .update({ amount_override: 30000 })
       .eq("id", instanceA!.id);
 
-    // Reload and check footer: should show 30000 + 20000 = 50000
+    // Reload — footer should increase by +20000 (override 30000 replaces template 10000)
     await page.reload();
     await expenses.selectTab("Servicios");
-
     await page.waitForLoadState("networkidle", { timeout: 10_000 });
-
-    // The footer total should reflect override (50000) not template (30000)
-    await expect(page.getByText("Total servicios")).toBeVisible({
-      timeout: 10_000,
-    });
-    await expect(page.getByTestId("fijos-total")).toHaveText("$50.000", {
-      timeout: 8_000,
-    });
+    await expect(page.getByText("Total servicios")).toBeVisible({ timeout: 10_000 });
+    const afterText = await page.getByTestId("fijos-total").innerText();
+    const after = Number(afterText.replace(/[^0-9]/g, ""));
+    expect(after, `footer debería haber aumentado en 20000 (baseline=${baseline})`).toBe(baseline + 20000);
   });
 });
 

--- a/e2e/fixed-review.spec.ts
+++ b/e2e/fixed-review.spec.ts
@@ -1,0 +1,340 @@
+import { test, expect } from "./fixtures";
+
+/**
+ * Fixed Expense Monthly Review E2E — covers SCEN-03 through SCEN-08.
+ *
+ * Approach: use adminClient for seed data instead of UI where possible,
+ * to keep test surface lean and minimize flakiness.
+ *
+ * Each test cleans up after itself via afterEach deleting by a unique description.
+ */
+
+/** Returns current month as YYYY-MM-01 (matches getMonthDate() format) */
+const currentMonth = (): string => {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-01`;
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Seeds a fixed expense template + instance directly in DB.
+ * Returns { templateId, instanceId }.
+ */
+async function seedFixedTemplate(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  adminClient: any,
+  coupleId: string,
+  description: string,
+  requiresMonthlyReview: boolean,
+) {
+  const { data: template, error: tErr } = await adminClient
+    .from("fixed_expense_templates")
+    .insert({
+      couple_id: coupleId,
+      description,
+      amount: 99_000,
+      due_day: 15,
+      requires_monthly_review: requiresMonthlyReview,
+    })
+    .select("id")
+    .single();
+  if (tErr || !template) throw new Error(`Template seed failed: ${tErr?.message}`);
+
+  const { data: instance, error: iErr } = await adminClient
+    .from("fixed_expense_instances")
+    .insert({
+      template_id: template.id,
+      couple_id: coupleId,
+      month: currentMonth(),
+      paid: false,
+      status: requiresMonthlyReview ? "PENDING_CONFIRMATION" : "CONFIRMED",
+    })
+    .select("id")
+    .single();
+  if (iErr || !instance) throw new Error(`Instance seed failed: ${iErr?.message}`);
+
+  return { templateId: template.id, instanceId: instance.id };
+}
+
+// ── SCEN-03: Template requires_monthly_review=true → instance shows "Sin confirmar" badge ──
+
+test.describe("SCEN-03: Template con review → instancia muestra badge", () => {
+  const DESC = `E2E-review-pending-${Date.now()}`;
+  let templateId: string;
+
+  test.beforeEach(async ({ adminClient, coupleId }) => {
+    const result = await seedFixedTemplate(
+      adminClient,
+      coupleId,
+      DESC,
+      true, // requires_monthly_review = true
+    );
+    templateId = result.templateId;
+  });
+
+  test.afterEach(async ({ adminClient }) => {
+    await adminClient
+      .from("fixed_expense_instances")
+      .delete()
+      .eq("template_id", templateId);
+    await adminClient
+      .from("fixed_expense_templates")
+      .delete()
+      .eq("id", templateId);
+  });
+
+  test("instancia PENDING muestra badge 'Sin confirmar'", async ({
+    authenticatedPage: page,
+  }) => {
+    test.slow();
+    await page.goto("/expenses");
+    await page.getByTestId("tab-servicios").click();
+    // Wait for the list to populate
+    await expect(page.getByText(DESC)).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.getByText("Sin confirmar").first(),
+    ).toBeVisible();
+  });
+});
+
+// ── SCEN-04: Confirmar instancia individual → badge desaparece ────────────────
+
+test.describe("SCEN-04: Confirmar instancia individual", () => {
+  const DESC = `E2E-review-confirm-${Date.now()}`;
+  let templateId: string;
+
+  test.beforeEach(async ({ adminClient, coupleId }) => {
+    const result = await seedFixedTemplate(adminClient, coupleId, DESC, true);
+    templateId = result.templateId;
+  });
+
+  test.afterEach(async ({ adminClient }) => {
+    await adminClient
+      .from("fixed_expense_instances")
+      .delete()
+      .eq("template_id", templateId);
+    await adminClient
+      .from("fixed_expense_templates")
+      .delete()
+      .eq("id", templateId);
+  });
+
+  test("click Confirmar elimina el badge 'Sin confirmar'", async ({
+    authenticatedPage: page,
+  }) => {
+    test.slow();
+    await page.goto("/expenses");
+    await page.getByTestId("tab-servicios").click();
+    await expect(page.getByText(DESC)).toBeVisible({ timeout: 10_000 });
+
+    // Find the Confirmar button for this item
+    const item = page.getByText(DESC).locator("..").locator("..");
+    const confirmBtn = page.getByRole("button", { name: "Confirmar" }).first();
+    await expect(confirmBtn).toBeVisible();
+    await confirmBtn.click();
+
+    // Badge should disappear after mutation + query invalidation
+    await expect(page.getByText("Sin confirmar")).not.toBeVisible({
+      timeout: 8_000,
+    });
+    // The item should still be present (just confirmed)
+    await expect(page.getByText(DESC)).toBeVisible();
+  });
+});
+
+// ── SCEN-05: "Confirmar todos" → todos los badges desaparecen ─────────────────
+
+test.describe("SCEN-05: Confirmar todos", () => {
+  const DESC1 = `E2E-review-all-1-${Date.now()}`;
+  const DESC2 = `E2E-review-all-2-${Date.now()}`;
+  const templateIds: string[] = [];
+
+  test.beforeEach(async ({ adminClient, coupleId }) => {
+    const r1 = await seedFixedTemplate(adminClient, coupleId, DESC1, true);
+    const r2 = await seedFixedTemplate(adminClient, coupleId, DESC2, true);
+    templateIds.push(r1.templateId, r2.templateId);
+  });
+
+  test.afterEach(async ({ adminClient }) => {
+    for (const id of templateIds) {
+      await adminClient
+        .from("fixed_expense_instances")
+        .delete()
+        .eq("template_id", id);
+      await adminClient
+        .from("fixed_expense_templates")
+        .delete()
+        .eq("id", id);
+    }
+    templateIds.length = 0;
+  });
+
+  test("'Confirmar todos' elimina todos los badges", async ({
+    authenticatedPage: page,
+  }) => {
+    test.slow();
+    await page.goto("/expenses");
+    await page.getByTestId("tab-servicios").click();
+    await expect(page.getByText(DESC1)).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(DESC2)).toBeVisible({ timeout: 5_000 });
+
+    // Button is visible because pendingFijosCount > 0
+    const confirmAllBtn = page.getByTestId("confirm-all-fijos");
+    await expect(confirmAllBtn).toBeVisible();
+    await confirmAllBtn.click();
+
+    // All "Sin confirmar" badges should disappear
+    await expect(page.getByText("Sin confirmar")).not.toBeVisible({
+      timeout: 8_000,
+    });
+    // Both items still present
+    await expect(page.getByText(DESC1)).toBeVisible();
+    await expect(page.getByText(DESC2)).toBeVisible();
+  });
+});
+
+// ── SCEN-06: Template requires_monthly_review=false → no badge ───────────────
+
+test.describe("SCEN-06: Template sin review → sin badge", () => {
+  const DESC = `E2E-review-none-${Date.now()}`;
+  let templateId: string;
+
+  test.beforeEach(async ({ adminClient, coupleId }) => {
+    const result = await seedFixedTemplate(
+      adminClient,
+      coupleId,
+      DESC,
+      false, // requires_monthly_review = false
+    );
+    templateId = result.templateId;
+  });
+
+  test.afterEach(async ({ adminClient }) => {
+    await adminClient
+      .from("fixed_expense_instances")
+      .delete()
+      .eq("template_id", templateId);
+    await adminClient
+      .from("fixed_expense_templates")
+      .delete()
+      .eq("id", templateId);
+  });
+
+  test("instancia CONFIRMED no muestra badge 'Sin confirmar'", async ({
+    authenticatedPage: page,
+  }) => {
+    test.slow();
+    await page.goto("/expenses");
+    await page.getByTestId("tab-servicios").click();
+    await expect(page.getByText(DESC)).toBeVisible({ timeout: 10_000 });
+    // There should be no "Sin confirmar" badge in the vicinity of this item
+    const item = page.getByText(DESC);
+    await expect(item).toBeVisible();
+    // The badge text should not be visible for a CONFIRMED item
+    // (There may be other PENDING items in the test account, so check locally)
+    const row = page.locator("div").filter({ hasText: DESC }).first();
+    await expect(row.getByText("Sin confirmar")).not.toBeVisible();
+  });
+});
+
+// ── SCEN-07: Dashboard muestra banner con count PENDING ───────────────────────
+
+test.describe("SCEN-07: Dashboard banner con instancias PENDING", () => {
+  const DESC = `E2E-review-banner-${Date.now()}`;
+  let templateId: string;
+
+  test.beforeEach(async ({ adminClient, coupleId }) => {
+    const result = await seedFixedTemplate(adminClient, coupleId, DESC, true);
+    templateId = result.templateId;
+  });
+
+  test.afterEach(async ({ adminClient }) => {
+    await adminClient
+      .from("fixed_expense_instances")
+      .delete()
+      .eq("template_id", templateId);
+    await adminClient
+      .from("fixed_expense_templates")
+      .delete()
+      .eq("id", templateId);
+  });
+
+  test("dashboard muestra banner de confirmación pendiente", async ({
+    authenticatedPage: page,
+  }) => {
+    test.slow();
+    await page.goto("/dashboard");
+    // Banner should be visible (count >= 1 PENDING instance)
+    await expect(
+      page.getByText(/necesita(n)? confirmación/i),
+    ).toBeVisible({ timeout: 12_000 });
+    // Banner links to /expenses
+    const bannerLink = page.getByRole("link", { name: /necesita/i });
+    await expect(bannerLink).toHaveAttribute("href", "/expenses");
+  });
+});
+
+// ── SCEN-08: Toggle en create-form persiste requires_monthly_review ───────────
+
+test.describe("SCEN-08: Toggle en create-form persiste el flag", () => {
+  const DESC = `E2E-review-toggle-${Date.now()}`;
+
+  test.afterEach(async ({ adminClient, coupleId }) => {
+    // Clean up any template created by this test
+    const { data: templates } = await adminClient
+      .from("fixed_expense_templates")
+      .select("id")
+      .eq("couple_id", coupleId)
+      .like("description", "E2E-review-toggle-%");
+    if (templates?.length) {
+      for (const t of templates) {
+        await adminClient
+          .from("fixed_expense_instances")
+          .delete()
+          .eq("template_id", t.id);
+      }
+      await adminClient
+        .from("fixed_expense_templates")
+        .delete()
+        .in(
+          "id",
+          templates.map((t) => t.id),
+        );
+    }
+  });
+
+  test("crear servicio con toggle ON → instancia nace con badge 'Sin confirmar'", async ({
+    authenticatedPage: page,
+  }) => {
+    test.slow();
+    await page.goto("/expenses");
+    await page.getByTestId("tab-servicios").click();
+
+    // Open the add sheet via FAB → TypeSelector → Servicio → ServiceList → Nuevo servicio
+    await page.getByRole("button", { name: "Agregar gasto" }).click();
+    await page.getByTestId("type-selector-sheet").waitFor({ state: "visible" });
+    await page.getByTestId("type-option-servicio").click();
+    await page.getByTestId("service-list-sheet").waitFor({ state: "visible" });
+    await page.getByText("+ Nuevo servicio").click();
+    await page.getByTestId("add-sheet-dialog").waitFor({ state: "visible" });
+
+    // Fill the form
+    await page.getByLabel("Descripción").fill(DESC);
+    await page.getByLabel("Monto").fill("45000");
+    await page.getByLabel("Día de vencimiento (1-31)").fill("10");
+
+    // Enable the "Pedirme confirmación cada mes" toggle
+    const toggle = page.getByTestId("toggle-requires-review");
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-pressed", "true");
+
+    // Save
+    await page.getByRole("button", { name: "Guardar" }).click();
+    await page.getByTestId("add-sheet-dialog").waitFor({ state: "hidden" });
+
+    // The new item should show the "Sin confirmar" badge
+    await expect(page.getByText(DESC)).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("Sin confirmar").first()).toBeVisible();
+  });
+});

--- a/e2e/fixed-review.spec.ts
+++ b/e2e/fixed-review.spec.ts
@@ -184,7 +184,7 @@ test.describe("SCEN-05: Confirmar todos", () => {
     await confirmAllBtn.click();
 
     // All "Sin confirmar" badges should disappear
-    await expect(page.getByText("Sin confirmar")).not.toBeVisible({
+    await expect(page.getByText("Sin confirmar")).toHaveCount(0, {
       timeout: 8_000,
     });
     // Both items still present

--- a/e2e/fixed-review.spec.ts
+++ b/e2e/fixed-review.spec.ts
@@ -269,7 +269,7 @@ test.describe("SCEN-07: Dashboard banner con instancias PENDING", () => {
       page.getByText(/necesita(n)? confirmación/i),
     ).toBeVisible({ timeout: 12_000 });
     // Banner links to /expenses
-    const bannerLink = page.getByRole("link", { name: /necesita/i });
+    const bannerLink = page.getByTestId("pending-review-link");
     await expect(bannerLink).toHaveAttribute("href", "/expenses");
   });
 });

--- a/e2e/fixed-review.spec.ts
+++ b/e2e/fixed-review.spec.ts
@@ -129,7 +129,6 @@ test.describe("SCEN-04: Confirmar instancia individual", () => {
     await expect(page.getByText(DESC)).toBeVisible({ timeout: 10_000 });
 
     // Find the Confirmar button for this item
-    const item = page.getByText(DESC).locator("..").locator("..");
     const confirmBtn = page.getByRole("button", { name: "Confirmar" }).first();
     await expect(confirmBtn).toBeVisible();
     await confirmBtn.click();

--- a/e2e/happy-path.spec.ts
+++ b/e2e/happy-path.spec.ts
@@ -293,6 +293,16 @@ test.describe("Dashboard — balance proporcional", () => {
     }
   });
 
+  test.beforeEach(async ({ adminClient, coupleId }) => {
+    // Remove any fixed expense instances for this month so parallel tests in expenses.spec.ts
+    // don't contaminate the balance calculation (shared coupleId + workers:2 in CI)
+    await adminClient
+      .from("fixed_expense_instances")
+      .delete()
+      .eq("couple_id", coupleId)
+      .eq("month", currentMonth);
+  });
+
   test.afterEach(async ({ adminClient, coupleId }) => {
     // Clean incomes for both users for current month
     await adminClient
@@ -307,6 +317,12 @@ test.describe("Dashboard — balance proporcional", () => {
       .delete()
       .eq("couple_id", coupleId)
       .like("description", "E2E-balance-math-%");
+    // Clean any fixed expense instances created by ensureFixedExpenseInstances during dashboard load
+    await adminClient
+      .from("fixed_expense_instances")
+      .delete()
+      .eq("couple_id", coupleId)
+      .eq("month", currentMonth);
   });
 
   test("TC-007: balance-debt-amount refleja el split proporcional", async ({

--- a/e2e/pages/nav.page.ts
+++ b/e2e/pages/nav.page.ts
@@ -20,8 +20,8 @@ export class BottomNav {
     const isTriggerVisible = await this.trigger.isVisible();
     if (isTriggerVisible) {
       await this.trigger.click();
-      // Wait for sidebar links to appear
-      await this.link("Inicio").waitFor({ state: "visible", timeout: 5_000 });
+      // Wait for sidebar links to appear (Sheet animation can be slow in CI)
+      await this.link("Inicio").waitFor({ state: "visible", timeout: 10_000 });
     }
   }
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,5 +10,5 @@ sonar.exclusions=**/node_modules/**,**/.next/**,**/coverage/**,**/playwright-rep
 # Custom hooks need DOM/React context — covered by Playwright e2e
 # Server Actions with Supabase — covered by Playwright e2e
 # Supabase client factories — infrastructure, not app logic
-sonar.coverage.exclusions=**/src/app/**,**/src/components/**,**/src/lib/actions/couple.ts,**/src/lib/providers.tsx,**/src/lib/supabase/**,**/src/lib/queries/**,**/src/lib/hooks/**
+sonar.coverage.exclusions=**/src/app/**,**/src/components/**,**/src/lib/actions/**,**/src/lib/providers.tsx,**/src/lib/supabase/**,**/src/lib/queries/**,**/src/lib/hooks/**
 sonar.sourceEncoding=UTF-8

--- a/src/app/(app)/dashboard/_components/pending-review-banner.tsx
+++ b/src/app/(app)/dashboard/_components/pending-review-banner.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+
+export function PendingReviewBanner({ count }: { readonly count: number }) {
+  if (count === 0) return null;
+  const plural = count > 1;
+  return (
+    <Link href="/expenses" style={{ textDecoration: "none" }}>
+      <Alert
+        className="mb-3 flex items-center gap-2 border-(--color-coral) py-2.5"
+        style={{
+          background: "color-mix(in srgb, var(--color-coral) 10%, transparent)",
+          cursor: "pointer",
+        }}
+      >
+        <AlertDescription
+          style={{ color: "var(--color-coral)" }}
+          className="text-[13px] font-medium"
+        >
+          {count} servicio{plural ? "s" : ""} necesita{plural ? "n" : ""}{" "}
+          confirmación — Revisar
+        </AlertDescription>
+      </Alert>
+    </Link>
+  );
+}

--- a/src/app/(app)/dashboard/_components/pending-review-banner.tsx
+++ b/src/app/(app)/dashboard/_components/pending-review-banner.tsx
@@ -5,7 +5,7 @@ export function PendingReviewBanner({ count }: { readonly count: number }) {
   if (count === 0) return null;
   const plural = count > 1;
   return (
-    <Link href="/expenses" style={{ textDecoration: "none" }}>
+    <Link href="/expenses" data-testid="pending-review-link" style={{ textDecoration: "none" }}>
       <Alert
         className="mb-3 flex items-center gap-2 border-(--color-coral) py-2.5"
         style={{

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -24,6 +24,7 @@ import { MonthSummaryCard } from "@/components/shared/month-summary-card";
 import { ensureFixedExpenseInstances } from "@/lib/actions/expenses";
 import { NoCoupleState } from "./_components/no-couple-state";
 import { NewInstancesBanner } from "./_components/new-instances-banner";
+import { PendingReviewBanner } from "./_components/pending-review-banner";
 import { BalanceCard } from "./_components/balance-card";
 import { CategoryBreakdownCard } from "./_components/category-breakdown-card";
 import { UpcomingDuesWidget } from "./_components/upcoming-dues-widget";
@@ -146,6 +147,11 @@ export default function DashboardPage() {
     ).slice(0, 5);
   }, [data, balance, categories]);
 
+  const pendingCount =
+    data?.fixedExpenseInstances.filter(
+      (fi) => fi.status === "PENDING_CONFIRMATION",
+    ).length ?? 0;
+
   const currentUserId = member?.user_id;
   const myProfile = profiles.find((p) => p.user_id === currentUserId);
   const partnerProfile = profiles.find((p) => p.user_id !== currentUserId);
@@ -187,6 +193,7 @@ export default function DashboardPage() {
             count={newInstancesBanner}
             onDismiss={() => setNewInstancesBanner(0)}
           />
+          <PendingReviewBanner count={pendingCount} />
 
           {/* Desktop: 2-col grid | Mobile: single column */}
           <div className="flex flex-col gap-3 lg:grid lg:grid-cols-2 lg:items-start lg:gap-5">

--- a/src/app/(app)/expenses/_components/add-sheet.tsx
+++ b/src/app/(app)/expenses/_components/add-sheet.tsx
@@ -20,29 +20,44 @@ import { computeMonthlyInstallment } from "@/lib/utils/installments";
 import { formatARS } from "@/lib/utils";
 
 // ── SCHEMAS ───────────────────────────────────────────────────────────────────
+
+function positiveMoneyString(field = "El monto") {
+  return z
+    .string()
+    .min(1, "Requerido")
+    .refine((v) => {
+      const n = Number(v.replace(",", ".").replace(/\./g, ""));
+      return !isNaN(n) && n > 0;
+    }, `${field} debe ser mayor a 0`);
+}
+
+function positiveIntString(max = 999) {
+  return z
+    .string()
+    .min(1, "Requerido")
+    .refine((v) => {
+      const n = Number.parseInt(v, 10);
+      return !isNaN(n) && n >= 1 && n <= max;
+    }, `Debe ser un número entre 1 y ${max}`);
+}
+
 const cuotasSchema = z.object({
   description: z.string().min(1, "Requerido"),
-  total_amount: z.string().min(1, "Requerido"),
-  installments: z.string().min(1, "Requerido"),
+  total_amount: positiveMoneyString("El monto total"),
+  installments: positiveIntString(999),
   first_payment_date: z.string().optional(),
   credit_card: z.string().trim().max(40).optional(),
 });
 
 const fijosSchema = z.object({
   description: z.string().min(1, "Requerido"),
-  amount: z.string().min(1, "Requerido"),
-  due_day: z.string().min(1, "Requerido"),
+  amount: positiveMoneyString(),
+  due_day: positiveIntString(31),
 });
 
 const variablesSchema = z.object({
   description: z.string().min(1, "Requerido"),
-  amount: z
-    .string()
-    .min(1, "Requerido")
-    .refine(
-      (v) => Number(v.replace(",", ".")) > 0,
-      "El monto debe ser mayor a 0",
-    ),
+  amount: positiveMoneyString(),
   date: z.string().optional(),
 });
 
@@ -196,6 +211,7 @@ export function AddSheet({
   categories,
   onClose,
   onSave,
+  saveError,
 }: {
   readonly tab: Tab;
   readonly categories: ReturnType<typeof useCategories>["data"];
@@ -206,6 +222,7 @@ export function AddSheet({
     autoRenew: boolean,
     requiresMonthlyReview: boolean,
   ) => void;
+  readonly saveError?: string | null;
 }) {
   const [categoryId, setCategoryId] = useState<string | null>(null);
   const [autoRenew, setAutoRenew] = useState(false);
@@ -473,6 +490,22 @@ export function AddSheet({
                   }}
                 />
               </button>
+            </div>
+          )}
+
+          {saveError && (
+            <div
+              role="alert"
+              style={{
+                ...errorCss,
+                marginBottom: 12,
+                padding: "8px 12px",
+                background: "color-mix(in srgb, var(--status-danger) 10%, transparent)",
+                borderRadius: 8,
+                border: "1px solid var(--status-danger)",
+              }}
+            >
+              {saveError}
             </div>
           )}
 

--- a/src/app/(app)/expenses/_components/add-sheet.tsx
+++ b/src/app/(app)/expenses/_components/add-sheet.tsx
@@ -204,10 +204,12 @@ export function AddSheet({
     data: Record<string, string>,
     categoryId: string | null,
     autoRenew: boolean,
+    requiresMonthlyReview: boolean,
   ) => void;
 }) {
   const [categoryId, setCategoryId] = useState<string | null>(null);
   const [autoRenew, setAutoRenew] = useState(false);
+  const [requiresMonthlyReview, setRequiresMonthlyReview] = useState(false);
 
   const {
     register,
@@ -234,6 +236,7 @@ export function AddSheet({
       ) as Record<string, string>,
       categoryId,
       autoRenew,
+      requiresMonthlyReview,
     );
   }
 
@@ -344,6 +347,60 @@ export function AddSheet({
               error={errors.due_day?.message}
               mono
             />
+          )}
+
+          {tab === "fijos" && (
+            <div
+              style={{
+                marginBottom: 14,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+              }}
+            >
+              <span
+                style={{
+                  fontSize: 13,
+                  fontWeight: 500,
+                  color: "var(--fg-2)",
+                  fontFamily: "var(--font-sans)",
+                }}
+              >
+                Pedirme confirmación cada mes
+              </span>
+              <button
+                type="button"
+                onClick={() => setRequiresMonthlyReview((v) => !v)}
+                data-testid="toggle-requires-review"
+                style={{
+                  width: 44,
+                  height: 26,
+                  borderRadius: 99,
+                  border: "none",
+                  cursor: "pointer",
+                  background: requiresMonthlyReview
+                    ? "var(--accent)"
+                    : "var(--border-default)",
+                  transition: "background 150ms",
+                  position: "relative",
+                }}
+                aria-label="Pedirme confirmación cada mes"
+                aria-pressed={requiresMonthlyReview}
+              >
+                <div
+                  style={{
+                    width: 20,
+                    height: 20,
+                    borderRadius: 99,
+                    background: "white",
+                    position: "absolute",
+                    top: 3,
+                    left: requiresMonthlyReview ? 21 : 3,
+                    transition: "left 150ms",
+                  }}
+                />
+              </button>
+            </div>
           )}
 
           {tab === "variables" && (

--- a/src/app/(app)/expenses/_components/fijo-item.tsx
+++ b/src/app/(app)/expenses/_components/fijo-item.tsx
@@ -6,6 +6,7 @@ import { formatARS } from "@/lib/utils";
 import {
   toggleFixedExpenseInstance,
   updateFixedExpenseInstanceAmount,
+  confirmFixedExpenseInstance,
 } from "@/lib/actions/expenses";
 import { effectiveFixedAmount } from "@/lib/utils/balance";
 import { useMonthlyData } from "@/lib/queries/use-monthly-data";
@@ -29,6 +30,14 @@ export function FijoItem({
   const hasOverride = fi.amount_override != null;
   const templateAmount = fi.fixed_expense_templates.amount;
   const activeAmount = effectiveFixedAmount(fi);
+  const isPending = fi.status === "PENDING_CONFIRMATION";
+
+  const confirmMutation = useMutation({
+    mutationFn: (instanceId: string) => confirmFixedExpenseInstance(instanceId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["monthly-data"] });
+    },
+  });
 
   const amountMutation = useMutation({
     mutationFn: ({
@@ -120,6 +129,24 @@ export function FijoItem({
             }}
           >
             editado
+          </span>
+        )}
+        {isPending && (
+          <span
+            style={{
+              display: "inline-block",
+              marginTop: 3,
+              background:
+                "color-mix(in srgb, var(--color-coral) 12%, transparent)",
+              color: "var(--color-coral)",
+              fontSize: 10,
+              fontWeight: 600,
+              borderRadius: 4,
+              padding: "1px 5px",
+              fontFamily: "var(--font-sans)",
+            }}
+          >
+            Sin confirmar
           </span>
         )}
       </div>
@@ -288,6 +315,31 @@ export function FijoItem({
           </div>
         )}
       </div>
+
+      {/* Confirm CTA — only shown when PENDING_CONFIRMATION */}
+      {isPending && (
+        <button
+          onClick={() => confirmMutation.mutate(fi.id)}
+          disabled={confirmMutation.isPending}
+          style={{
+            height: 28,
+            paddingInline: 10,
+            borderRadius: 8,
+            border: `1.5px solid var(--color-coral)`,
+            background:
+              "color-mix(in srgb, var(--color-coral) 10%, transparent)",
+            color: "var(--color-coral)",
+            cursor: confirmMutation.isPending ? "not-allowed" : "pointer",
+            fontSize: 11,
+            fontWeight: 600,
+            fontFamily: "var(--font-sans)",
+            flexShrink: 0,
+            opacity: confirmMutation.isPending ? 0.5 : 1,
+          }}
+        >
+          Confirmar
+        </button>
+      )}
 
       {/* Right: paid toggle */}
       <button

--- a/src/app/(app)/expenses/page.tsx
+++ b/src/app/(app)/expenses/page.tsx
@@ -15,6 +15,7 @@ import { useExpenseSave, type Tab } from "@/lib/queries/use-expense-save";
 import {
   updateFixedExpenseInstanceAmount,
   toggleFixedExpenseInstance,
+  confirmAllFixedExpenseInstances,
 } from "@/lib/actions/expenses";
 import { CuotaItem } from "./_components/cuota-item";
 import { FijoItem } from "./_components/fijo-item";
@@ -662,14 +663,29 @@ export default function ExpensesPage() {
     fields: Record<string, string>,
     categoryId: string | null,
     autoRenew: boolean,
+    requiresMonthlyReview: boolean,
   ) {
     setFlow({ step: "idle" });
-    save(fields, categoryId, autoRenew);
+    save(fields, categoryId, autoRenew, requiresMonthlyReview);
   }
+
+  const queryClient = useQueryClient();
+
+  const confirmAllMutation = useMutation({
+    mutationFn: () =>
+      confirmAllFixedExpenseInstances(coupleId!, month),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["monthly-data"] });
+    },
+  });
 
   const allCuotas = data?.installmentPurchases ?? [];
   const allFijos = data?.fixedExpenseInstances ?? [];
   const allVariables = data?.variableExpenses ?? [];
+
+  const pendingFijosCount = allFijos.filter(
+    (fi) => fi.status === "PENDING_CONFIRMATION",
+  ).length;
 
   const cuotas = filterCategory
     ? allCuotas.filter((c) => c.category_id === filterCategory)
@@ -854,6 +870,32 @@ export default function ExpensesPage() {
               )}
               {fijos.length > 0 && (
                 <>
+                  {pendingFijosCount > 0 && coupleId && (
+                    <div style={{ marginBottom: 8, display: "flex", justifyContent: "flex-end" }}>
+                      <button
+                        data-testid="confirm-all-fijos"
+                        onClick={() => confirmAllMutation.mutate()}
+                        disabled={confirmAllMutation.isPending}
+                        style={{
+                          padding: "6px 14px",
+                          borderRadius: 8,
+                          border: `1.5px solid var(--color-coral)`,
+                          background:
+                            "color-mix(in srgb, var(--color-coral) 10%, transparent)",
+                          color: "var(--color-coral)",
+                          cursor: confirmAllMutation.isPending
+                            ? "not-allowed"
+                            : "pointer",
+                          fontSize: 13,
+                          fontWeight: 600,
+                          fontFamily: "var(--font-sans)",
+                          opacity: confirmAllMutation.isPending ? 0.5 : 1,
+                        }}
+                      >
+                        Confirmar todos
+                      </button>
+                    </div>
+                  )}
                   <div
                     style={{
                       display: "flex",

--- a/src/app/(app)/expenses/page.tsx
+++ b/src/app/(app)/expenses/page.tsx
@@ -938,6 +938,7 @@ export default function ExpensesPage() {
                       Total servicios
                     </span>
                     <span
+                      data-testid="fijos-total"
                       style={{
                         fontFamily: "var(--font-mono)",
                         fontSize: 15,

--- a/src/app/(app)/expenses/page.tsx
+++ b/src/app/(app)/expenses/page.tsx
@@ -636,7 +636,7 @@ export default function ExpensesPage() {
   const [tab, setTab] = useState<Tab>("cuotas");
   const [flow, setFlow] = useState<FlowState>({ step: "idle" });
   const [filterCategory, setFilterCategory] = useState<string | null>(null);
-  const { save } = useExpenseSave(tab);
+  const { save, saveError } = useExpenseSave(tab);
 
   function handleTabChange(newTab: Tab) {
     setTab(newTab);
@@ -1040,6 +1040,7 @@ export default function ExpensesPage() {
           categories={categories}
           onClose={() => setFlow({ step: "idle" })}
           onSave={handleSave}
+          saveError={saveError}
         />
       )}
     </main>

--- a/src/lib/actions/expenses.ts
+++ b/src/lib/actions/expenses.ts
@@ -112,6 +112,7 @@ export async function createFixedExpenseTemplate(data: {
   amount: number;
   due_day: number;
   category_id?: string;
+  requires_monthly_review?: boolean;
 }) {
   const { supabase, coupleId } = await getCouple();
   const { data: template, error } = await supabase
@@ -127,8 +128,62 @@ export async function createFixedExpenseTemplate(data: {
       couple_id: coupleId,
       month,
       paid: false,
+      status: data.requires_monthly_review
+        ? "PENDING_CONFIRMATION"
+        : "CONFIRMED",
     });
   }
+  revalidatePath("/expenses");
+  revalidatePath("/dashboard");
+}
+
+export async function updateFixedExpenseTemplate(
+  templateId: string,
+  data: {
+    requires_monthly_review?: boolean;
+    description?: string;
+    amount?: number;
+    due_day?: number;
+    category_id?: string | null;
+  },
+): Promise<void> {
+  const { supabase } = await getCouple();
+  const { error } = await supabase
+    .from("fixed_expense_templates")
+    .update(data)
+    .eq("id", templateId);
+  if (error) throw new Error("No se pudo actualizar el servicio");
+  revalidatePath("/expenses");
+  revalidatePath("/dashboard");
+}
+
+export async function confirmFixedExpenseInstance(
+  instanceId: string,
+): Promise<void> {
+  const { supabase } = await getCouple();
+  const { error } = await supabase
+    .from("fixed_expense_instances")
+    .update({ status: "CONFIRMED" })
+    .eq("id", instanceId)
+    .eq("status", "PENDING_CONFIRMATION"); // idempotent; no-op if already confirmed
+  if (error) throw new Error("No se pudo confirmar el servicio");
+  revalidatePath("/expenses");
+  revalidatePath("/dashboard");
+}
+
+export async function confirmAllFixedExpenseInstances(
+  coupleId: string,
+  month: string,
+): Promise<void> {
+  const { supabase, coupleId: myCoupleId } = await getCouple();
+  if (coupleId !== myCoupleId) throw new Error("Pareja inválida");
+  const { error } = await supabase
+    .from("fixed_expense_instances")
+    .update({ status: "CONFIRMED" })
+    .eq("couple_id", coupleId)
+    .eq("month", month)
+    .eq("status", "PENDING_CONFIRMATION");
+  if (error) throw new Error("No se pudieron confirmar los servicios");
   revalidatePath("/expenses");
   revalidatePath("/dashboard");
 }
@@ -175,7 +230,7 @@ export async function ensureFixedExpenseInstances(
 
   const { data: templates } = await supabase
     .from("fixed_expense_templates")
-    .select("id")
+    .select("id, requires_monthly_review")
     .eq("couple_id", coupleId)
     .eq("active", true);
 
@@ -195,6 +250,7 @@ export async function ensureFixedExpenseInstances(
       couple_id: coupleId,
       month,
       paid: false,
+      status: t.requires_monthly_review ? "PENDING_CONFIRMATION" : "CONFIRMED",
     }));
 
   if (toCreate.length) {

--- a/src/lib/queries/use-expense-save.ts
+++ b/src/lib/queries/use-expense-save.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   createInstallmentPurchase,
@@ -10,8 +10,21 @@ import {
 
 export type Tab = "cuotas" | "fijos" | "variables";
 
+function parsePositiveNumber(value: string | undefined): number {
+  const n = Number(value?.replace(",", ".").replace(/\./g, "") ?? "");
+  if (isNaN(n) || n <= 0) throw new Error(`Monto inválido: "${value}"`);
+  return n;
+}
+
+function parsePositiveInt(value: string | undefined): number {
+  const n = Number.parseInt(value ?? "", 10);
+  if (isNaN(n) || n < 1) throw new Error(`Número inválido: "${value}"`);
+  return n;
+}
+
 export function useExpenseSave(tab: Tab) {
   const [isPending, startTransition] = useTransition();
+  const [saveError, setSaveError] = useState<string | null>(null);
   const queryClient = useQueryClient();
 
   function save(
@@ -20,37 +33,45 @@ export function useExpenseSave(tab: Tab) {
     autoRenew: boolean,
     requiresMonthlyReview = false,
   ) {
+    setSaveError(null);
     startTransition(async () => {
-      if (tab === "cuotas") {
-        await createInstallmentPurchase({
-          description: fields.description,
-          total_amount: Number.parseFloat(fields.total_amount),
-          installments: Number.parseInt(fields.installments),
-          first_payment_date:
-            fields.first_payment_date || new Date().toISOString().slice(0, 10),
-          category_id: categoryId ?? undefined,
-          auto_renew: autoRenew || undefined,
-          credit_card: fields.credit_card?.trim() || null,
-        });
-      } else if (tab === "fijos") {
-        await createFixedExpenseTemplate({
-          description: fields.description,
-          amount: Number.parseFloat(fields.amount),
-          due_day: Number.parseInt(fields.due_day),
-          category_id: categoryId ?? undefined,
-          requires_monthly_review: requiresMonthlyReview || undefined,
-        });
-      } else {
-        await createVariableExpense({
-          description: fields.description,
-          amount: Number.parseFloat(fields.amount),
-          date: fields.date || new Date().toISOString().slice(0, 10),
-          category_id: categoryId ?? undefined,
-        });
+      try {
+        if (tab === "cuotas") {
+          await createInstallmentPurchase({
+            description: fields.description,
+            total_amount: parsePositiveNumber(fields.total_amount),
+            installments: parsePositiveInt(fields.installments),
+            first_payment_date:
+              fields.first_payment_date ||
+              new Date().toISOString().slice(0, 10),
+            category_id: categoryId ?? undefined,
+            auto_renew: autoRenew || undefined,
+            credit_card: fields.credit_card?.trim() || null,
+          });
+        } else if (tab === "fijos") {
+          await createFixedExpenseTemplate({
+            description: fields.description,
+            amount: parsePositiveNumber(fields.amount),
+            due_day: parsePositiveInt(fields.due_day),
+            category_id: categoryId ?? undefined,
+            requires_monthly_review: requiresMonthlyReview || undefined,
+          });
+        } else {
+          await createVariableExpense({
+            description: fields.description,
+            amount: parsePositiveNumber(fields.amount),
+            date: fields.date || new Date().toISOString().slice(0, 10),
+            category_id: categoryId ?? undefined,
+          });
+        }
+        queryClient.invalidateQueries({ queryKey: ["monthly-data"] });
+      } catch (err) {
+        setSaveError(
+          err instanceof Error ? err.message : "No se pudo guardar el gasto",
+        );
       }
-      queryClient.invalidateQueries({ queryKey: ["monthly-data"] });
     });
   }
 
-  return { save, isPending };
+  return { save, isPending, saveError };
 }

--- a/src/lib/queries/use-expense-save.ts
+++ b/src/lib/queries/use-expense-save.ts
@@ -18,6 +18,7 @@ export function useExpenseSave(tab: Tab) {
     fields: Record<string, string>,
     categoryId: string | null,
     autoRenew: boolean,
+    requiresMonthlyReview = false,
   ) {
     startTransition(async () => {
       if (tab === "cuotas") {
@@ -37,6 +38,7 @@ export function useExpenseSave(tab: Tab) {
           amount: Number.parseFloat(fields.amount),
           due_day: Number.parseInt(fields.due_day),
           category_id: categoryId ?? undefined,
+          requires_monthly_review: requiresMonthlyReview || undefined,
         });
       } else {
         await createVariableExpense({

--- a/src/lib/utils/__tests__/balance.test.ts
+++ b/src/lib/utils/__tests__/balance.test.ts
@@ -130,6 +130,7 @@ describe("calculateMonthlyBalance", () => {
           month: "2026-04-01",
           paid: true,
           created_at: "",
+          status: "CONFIRMED" as string,
           amount_override: null as number | null,
           fixed_expense_templates: {
             id: "t1",
@@ -139,6 +140,7 @@ describe("calculateMonthlyBalance", () => {
             amount: 500_000,
             due_day: 9,
             active: true,
+            requires_monthly_review: false,
             created_at: "",
           },
         },
@@ -149,6 +151,7 @@ describe("calculateMonthlyBalance", () => {
           month: "2026-04-01",
           paid: false,
           created_at: "",
+          status: "CONFIRMED" as string,
           amount_override: null as number | null,
           fixed_expense_templates: {
             id: "t2",
@@ -158,6 +161,7 @@ describe("calculateMonthlyBalance", () => {
             amount: 68_740,
             due_day: 31,
             active: true,
+            requires_monthly_review: false,
             created_at: "",
           },
         },
@@ -374,6 +378,7 @@ describe("calculateMonthlyBalance", () => {
       amount: 100_000,
       due_day: 15,
       active: true,
+      requires_monthly_review: false,
       created_at: "",
     };
     const baseInstance = {
@@ -383,6 +388,7 @@ describe("calculateMonthlyBalance", () => {
       month: "2026-04-01",
       paid: false,
       created_at: "",
+      status: "CONFIRMED" as string,
       amount_override: null as number | null,
       fixed_expense_templates: baseTemplate,
     };
@@ -541,6 +547,7 @@ describe("effectiveFixedAmount", () => {
     amount: 12_000,
     due_day: 10,
     active: true,
+    requires_monthly_review: false,
     created_at: "",
   };
   const baseInstance = {
@@ -550,6 +557,7 @@ describe("effectiveFixedAmount", () => {
     month: "2026-04-01",
     paid: false,
     created_at: "",
+    status: "CONFIRMED" as string,
     amount_override: null as number | null,
     fixed_expense_templates: baseTemplate,
   };
@@ -571,5 +579,78 @@ describe("effectiveFixedAmount", () => {
       amount_override: "9999.99" as unknown as number | null,
     };
     expect(effectiveFixedAmount(instance)).toBe(9999.99);
+  });
+});
+
+// ── SCEN-01 / SCEN-02: status field does not affect balance math ──────────────
+
+describe("calculateMonthlyBalance — PENDING_CONFIRMATION status (RF-07)", () => {
+  const template = {
+    id: "t1",
+    couple_id: "c1",
+    category_id: null,
+    description: "Luz",
+    amount: 80_000,
+    due_day: 15,
+    active: true,
+    requires_monthly_review: true,
+    created_at: "",
+  };
+
+  const pendingInstance = {
+    id: "fi1",
+    template_id: "t1",
+    couple_id: "c1",
+    month: "2026-04-01",
+    paid: false,
+    created_at: "",
+    status: "PENDING_CONFIRMATION" as string,
+    amount_override: null as number | null,
+    fixed_expense_templates: template,
+  };
+
+  const confirmedInstance = {
+    ...pendingInstance,
+    status: "CONFIRMED" as string,
+  };
+
+  const incomes = [
+    {
+      id: "1",
+      couple_id: "c1",
+      user_id: "user-a",
+      amount: 1_000_000,
+      month: "2026-04-01",
+      created_at: "",
+    },
+  ];
+
+  // SCEN-01: PENDING_CONFIRMATION instance is included in fixed total — same as CONFIRMED
+  it("SCEN-01: instancia PENDING_CONFIRMATION se incluye en el total de gastos fijos", () => {
+    const result = calculateMonthlyBalance({
+      incomes,
+      installmentPurchases: [],
+      fixedExpenseInstances: [pendingInstance],
+      variableExpenses: [],
+    });
+    expect(result.fixedTotal).toBe(80_000);
+  });
+
+  // SCEN-02: CONFIRMED instance produces identical result — non-regression
+  it("SCEN-02: instancia CONFIRMED produce el mismo total que PENDING_CONFIRMATION", () => {
+    const pendingResult = calculateMonthlyBalance({
+      incomes,
+      installmentPurchases: [],
+      fixedExpenseInstances: [pendingInstance],
+      variableExpenses: [],
+    });
+    const confirmedResult = calculateMonthlyBalance({
+      incomes,
+      installmentPurchases: [],
+      fixedExpenseInstances: [confirmedInstance],
+      variableExpenses: [],
+    });
+    expect(pendingResult.fixedTotal).toBe(confirmedResult.fixedTotal);
+    expect(pendingResult.totalExpenses).toBe(confirmedResult.totalExpenses);
   });
 });

--- a/src/lib/utils/__tests__/due-dates.test.ts
+++ b/src/lib/utils/__tests__/due-dates.test.ts
@@ -24,6 +24,7 @@ function makeTemplate(
     due_day: 10,
     active: true,
     category_id: null,
+    requires_monthly_review: false,
     created_at: "2026-01-01T00:00:00Z",
     ...overrides,
   };
@@ -43,6 +44,7 @@ function makeInstance(
     month: "2026-05-01",
     paid: false,
     amount_override: null,
+    status: "CONFIRMED",
     created_at: "2026-05-01T00:00:00Z",
     ...instanceOverrides,
     fixed_expense_templates: makeTemplate(templateOverrides),

--- a/src/lib/utils/balance.ts
+++ b/src/lib/utils/balance.ts
@@ -1,5 +1,7 @@
 import type { Database } from "@/types/database";
 
+export type FixedInstanceStatus = "PENDING_CONFIRMATION" | "CONFIRMED";
+
 type Income = Database["public"]["Tables"]["incomes"]["Row"];
 type InstallmentPurchase =
   Database["public"]["Tables"]["installment_purchases"]["Row"];

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -7,6 +7,31 @@ export type Json =
   | Json[];
 
 export type Database = {
+  graphql_public: {
+    Tables: {
+      [_ in never]: never;
+    };
+    Views: {
+      [_ in never]: never;
+    };
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json;
+          operationName?: string;
+          query?: string;
+          variables?: Json;
+        };
+        Returns: Json;
+      };
+    };
+    Enums: {
+      [_ in never]: never;
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
+  };
   public: {
     Tables: {
       couple_members: {
@@ -105,6 +130,7 @@ export type Database = {
           id: string;
           month: string;
           paid: boolean;
+          status: string;
           template_id: string;
         };
         Insert: {
@@ -114,6 +140,7 @@ export type Database = {
           id?: string;
           month: string;
           paid?: boolean;
+          status?: string;
           template_id: string;
         };
         Update: {
@@ -123,6 +150,7 @@ export type Database = {
           id?: string;
           month?: string;
           paid?: boolean;
+          status?: string;
           template_id?: string;
         };
         Relationships: [
@@ -152,6 +180,7 @@ export type Database = {
           description: string;
           due_day: number;
           id: string;
+          requires_monthly_review: boolean;
         };
         Insert: {
           active?: boolean;
@@ -162,6 +191,7 @@ export type Database = {
           description: string;
           due_day: number;
           id?: string;
+          requires_monthly_review?: boolean;
         };
         Update: {
           active?: boolean;
@@ -172,6 +202,7 @@ export type Database = {
           description?: string;
           due_day?: number;
           id?: string;
+          requires_monthly_review?: boolean;
         };
         Relationships: [
           {
@@ -521,6 +552,9 @@ export type CompositeTypes<
     : never;
 
 export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
   public: {
     Enums: {
       couple_status: ["PENDING", "ACTIVE"],

--- a/supabase/migrations/20260606120000_add_fixed_review.sql
+++ b/supabase/migrations/20260606120000_add_fixed_review.sql
@@ -1,0 +1,18 @@
+-- Add requires_monthly_review flag to templates
+alter table fixed_expense_templates
+  add column requires_monthly_review boolean not null default false;
+
+comment on column fixed_expense_templates.requires_monthly_review is
+  'When true, each month''s generated instance starts as PENDING_CONFIRMATION until the user verifies the amount.';
+
+-- Add status column to instances (text + CHECK — matches codebase convention, evolvable)
+alter table fixed_expense_instances
+  add column status text not null default 'CONFIRMED'
+    constraint fixed_instance_status_check
+      check (status in ('PENDING_CONFIRMATION', 'CONFIRMED'));
+
+comment on column fixed_expense_instances.status is
+  'PENDING_CONFIRMATION = amount unverified for this month; CONFIRMED = user-verified or auto-confirmed (template not flagged).';
+
+-- Composite index for bulk-confirm queries and banner count
+create index on fixed_expense_instances (couple_id, month, status);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
         // Custom hooks need DOM/React context — covered by Playwright e2e
         "src/lib/hooks/**",
         // Server Actions with Supabase calls — covered by Playwright e2e
-        "src/lib/actions/couple.ts",
+        "src/lib/actions/**",
         // Supabase client factories and React providers — infrastructure
         "src/lib/supabase/**",
         "src/lib/providers.tsx",


### PR DESCRIPTION
## Summary

- Adds `requires_monthly_review` boolean flag per fixed expense template (default `false`)
- Instances of flagged templates are created with `status = PENDING_CONFIRMATION` each month instead of auto-confirming
- New `PendingReviewBanner` in dashboard shows pending count with link to /expenses
- `FijoItem` shows a "Sin confirmar" pill + "Confirmar" CTA for pending instances
- "Confirmar todos" button in expenses page for bulk confirmation
- Toggle in the create-template form to opt-in per service

## Motivation

The previous system copied last month's amount silently — even for services like electricity, gas, or rent that can change any month. The distinction is not FIXED vs VARIABLE (anything can change), but whether **the user wants to review it**. This feature gives that control per service.

## Technical decisions

- `text` + `CHECK` constraint for `status` (not a Postgres enum) — matches existing convention (`couples.status`, `couple_members.role`) and is evolvable
- PENDING instances **do** count in the balance — the estimated amount is the best approximation; uncertainty is surfaced visually only (zero change to `balance.ts` math)
- `paid` boolean stays orthogonal to `status` — a service can be confirmed but unpaid, or pending and paid
- Existing rows default to `CONFIRMED`, existing templates default to `false` — zero disruption on deploy

## Test plan

- [ ] 110 Vitest unit tests passing (balance fixtures updated with new `status` field)
- [ ] SCEN-03: template with `requires_monthly_review=true` → instance born PENDING → badge visible
- [ ] SCEN-04: confirm individual instance → badge disappears
- [ ] SCEN-05: "Confirmar todos" → all badges disappear
- [ ] SCEN-06: template with `requires_monthly_review=false` → instance born CONFIRMED → no badge
- [ ] SCEN-07: dashboard shows banner when PENDING instances exist
- [ ] SCEN-08: toggle in create-form persists flag in DB