### PR TITLE
fix(e2e): workers=1 en CI + set -e en pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+set -e
 npx tsc --noEmit
 npm run test:coverage
 npm run test:a11y

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   globalSetup: "./e2e/global-setup.ts",
   fullyParallel: false,
   retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? 2 : 1,
+  workers: 1,
   reporter: process.env.CI
     ? [["github"], ["html"]]
     : [["list"], ["html", { open: "never" }]],


### PR DESCRIPTION
## Summary

- `playwright.config.ts`: cambia `workers: process.env.CI ? 2 : 1` → `workers: 1` para eliminar race conditions entre test files en CI
- `.husky/pre-push`: agrega `set -e` para que cualquier comando fallido (tsc, coverage, a11y) detenga el push

## Root cause

Con `workers: 2` en CI, `happy-path.spec.ts` y `settings-income.spec.ts` corren en paralelo sobre el mismo `testUserId`/`coupleId`. El `afterEach` de settings-income borra el ingreso de testUser mientras TC-007 lo tiene seteado, corrompiendo el cálculo de balance. Resultado: TC-007 recibe `$30.000` en vez de `$10.000`, y TC-009 encuentra 1 registro de ingreso en lugar de 0.

## Changes

| File | Change |
|------|--------|
| `playwright.config.ts` | `workers: 1` — serial execution in CI eliminates cross-file data races |
| `.husky/pre-push` | `set -e` — script exits on first failing command |

## Test plan

- [x] 255 unit tests pass, coverage above thresholds
- [x] 11 a11y tests pass (now using 1 worker, up from 7 — additional landmark tests active)
- [ ] CI E2E suite should now pass TC-007 and TC-009 deterministically