### PR TITLE
fix(layout): constrain content width on desktop for expenses, history, settings

### DIFF
--- a/src/app/(app)/expenses/_components/add-sheet.tsx
+++ b/src/app/(app)/expenses/_components/add-sheet.tsx
@@ -8,12 +8,7 @@ import type { UseFormRegisterReturn } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
+import { ResponsiveModal } from "@/components/shared/responsive-modal";
 import { CategoryPicker } from "@/components/shared/category-picker";
 import { PersonAvatar } from "@/components/shared/avatar";
 import { useCategories } from "@/lib/queries/use-monthly-data";
@@ -29,10 +24,10 @@ function positiveMoneyString(field = "El monto") {
   return z
     .string()
     .min(1, "Requerido")
-    .refine(
-      (v) => { const n = parseAmount(v); return !Number.isNaN(n) && n > 0; },
-      `${field} debe ser mayor a 0`,
-    );
+    .refine((v) => {
+      const n = parseAmount(v);
+      return !Number.isNaN(n) && n > 0;
+    }, `${field} debe ser mayor a 0`);
 }
 
 function positiveIntString(max = 999) {
@@ -141,7 +136,7 @@ function MoneyField({
           placeholder="0"
           className={cn(
             "flex-1 border-none bg-transparent shadow-none outline-none focus-visible:ring-0",
-            "font-mono font-semibold text-base",
+            "font-mono text-base font-semibold",
           )}
           style={{
             padding: "10px 12px 10px 4px",
@@ -268,271 +263,133 @@ export function AddSheet({
   }
 
   return (
-    <Sheet open onOpenChange={(open) => !open && onClose()}>
-      <SheetContent
-        data-testid="add-sheet-dialog"
-        side="bottom"
-        showCloseButton={false}
-        aria-describedby={undefined}
-        className="mx-auto w-full sm:max-w-120 rounded-t-[20px]"
-        style={{
-          padding: "20px 20px 40px",
-          background: "var(--bg-elevated)",
-          border: "none",
-        }}
-      >
-        <div
-          style={{
-            width: 36,
-            height: 4,
-            borderRadius: 99,
-            background: "var(--border-default)",
-            margin: "0 auto 20px",
-          }}
+    <ResponsiveModal
+      open
+      onOpenChange={(open) => !open && onClose()}
+      title={`Nuevo gasto — ${TAB_LABEL[tab]}`}
+      data-testid="add-sheet-dialog"
+    >
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <InputField
+          label="Descripción"
+          id="field-description"
+          registration={register("description")}
+          error={errors.description?.message}
         />
-        <SheetHeader style={{ marginBottom: 16 }}>
-          <SheetTitle
-            style={{
-              fontSize: 18,
-              fontWeight: 700,
-              color: "var(--fg-1)",
-              fontFamily: "var(--font-sans)",
-              textTransform: "capitalize",
-            }}
-          >
-            Nuevo gasto — {TAB_LABEL[tab]}
-          </SheetTitle>
-        </SheetHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <InputField
-            label="Descripción"
-            id="field-description"
-            registration={register("description")}
-            error={errors.description?.message}
-          />
-
-          {tab === "cuotas" && (
-            <>
-              <MoneyField
-                label="Monto total"
-                id="field-total-amount"
-                registration={register("total_amount")}
-                error={errors.total_amount?.message}
-              />
-              <InputField
-                label="Cuotas"
-                id="field-installments"
-                registration={register("installments")}
-                error={errors.installments?.message}
-                inputMode="numeric"
-                mono
-              />
-              {monthlyAmount !== null && (
-                <div
-                  style={{
-                    fontSize: 12,
-                    color: "var(--fg-2)",
-                    marginTop: -10,
-                    marginBottom: 14,
-                    fontFamily: "var(--font-sans)",
-                  }}
-                >
-                  ≈ {formatARS(monthlyAmount)} / mes
-                </div>
-              )}
-              <InputField
-                label="Tarjeta (opcional)"
-                id="field-credit-card"
-                registration={register("credit_card")}
-                error={errors.credit_card?.message}
-              />
-              <InputField
-                label="Fecha del primer pago"
-                id="field-first-payment-date"
-                registration={register("first_payment_date")}
-                error={errors.first_payment_date?.message}
-                type="date"
-              />
-            </>
-          )}
-
-          {(tab === "fijos" || tab === "variables") && (
+        {tab === "cuotas" && (
+          <>
             <MoneyField
-              label="Monto"
-              id="field-amount"
-              registration={register("amount")}
-              error={errors.amount?.message}
+              label="Monto total"
+              id="field-total-amount"
+              registration={register("total_amount")}
+              error={errors.total_amount?.message}
             />
-          )}
-
-          {tab === "fijos" && (
             <InputField
-              label="Día de vencimiento (1-31)"
-              id="field-due-day"
-              registration={register("due_day")}
-              error={errors.due_day?.message}
+              label="Cuotas"
+              id="field-installments"
+              registration={register("installments")}
+              error={errors.installments?.message}
+              inputMode="numeric"
               mono
             />
-          )}
-
-          {tab === "fijos" && (
-            <div
-              style={{
-                marginBottom: 14,
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-              }}
-            >
-              <span
+            {monthlyAmount !== null && (
+              <div
                 style={{
-                  fontSize: 13,
-                  fontWeight: 500,
+                  fontSize: 12,
                   color: "var(--fg-2)",
+                  marginTop: -10,
+                  marginBottom: 14,
                   fontFamily: "var(--font-sans)",
                 }}
               >
-                Pedirme confirmación cada mes
-              </span>
-              <Switch
-                checked={requiresMonthlyReview}
-                onCheckedChange={setRequiresMonthlyReview}
-                data-testid="toggle-requires-review"
-                aria-label="Pedirme confirmación cada mes"
-              />
-            </div>
-          )}
-
-          {tab === "variables" && (
+                ≈ {formatARS(monthlyAmount)} / mes
+              </div>
+            )}
             <InputField
-              label="Fecha (AAAA-MM-DD)"
-              id="field-date"
-              registration={register("date")}
-              error={errors.date?.message}
+              label="Tarjeta (opcional)"
+              id="field-credit-card"
+              registration={register("credit_card")}
+              error={errors.credit_card?.message}
+            />
+            <InputField
+              label="Fecha del primer pago"
+              id="field-first-payment-date"
+              registration={register("first_payment_date")}
+              error={errors.first_payment_date?.message}
               type="date"
             />
-          )}
+          </>
+        )}
 
-          {tab === "variables" && (
-            <div
+        {(tab === "fijos" || tab === "variables") && (
+          <MoneyField
+            label="Monto"
+            id="field-amount"
+            registration={register("amount")}
+            error={errors.amount?.message}
+          />
+        )}
+
+        {tab === "fijos" && (
+          <InputField
+            label="Día de vencimiento (1-31)"
+            id="field-due-day"
+            registration={register("due_day")}
+            error={errors.due_day?.message}
+            mono
+          />
+        )}
+
+        {tab === "fijos" && (
+          <div
+            style={{
+              marginBottom: 14,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
+            <span
               style={{
-                marginBottom: 14,
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
+                fontSize: 13,
+                fontWeight: 500,
+                color: "var(--fg-2)",
+                fontFamily: "var(--font-sans)",
               }}
             >
-              <div>
-                <div
-                  style={{
-                    fontSize: 13,
-                    fontWeight: 500,
-                    color: "var(--fg-2)",
-                    fontFamily: "var(--font-sans)",
-                  }}
-                >
-                  {isShared ? "Gasto compartido" : "Gasto personal"}
-                </div>
-                <div
-                  style={{
-                    fontSize: 11,
-                    color: "var(--fg-3)",
-                    fontFamily: "var(--font-sans)",
-                    marginTop: 2,
-                  }}
-                >
-                  {isShared
-                    ? "Entra en el balance proporcional"
-                    : "No afecta el balance entre los dos"}
-                </div>
-              </div>
-              <Switch
-                checked={isShared}
-                onCheckedChange={setIsShared}
-                data-testid="toggle-is-shared"
-                aria-label="Gasto compartido"
-              />
-            </div>
-          )}
+              Pedirme confirmación cada mes
+            </span>
+            <Switch
+              checked={requiresMonthlyReview}
+              onCheckedChange={setRequiresMonthlyReview}
+              data-testid="toggle-requires-review"
+              aria-label="Pedirme confirmación cada mes"
+            />
+          </div>
+        )}
 
-          {categories && categories.length > 0 && (
-            <div style={{ marginBottom: 14 }}>
-              <div style={{ ...labelCss, marginBottom: 8 }}>Categoría</div>
-              <CategoryPicker
-                categories={categories}
-                value={categoryId}
-                onChange={setCategoryId}
-              />
-            </div>
-          )}
+        {tab === "variables" && (
+          <InputField
+            label="Fecha (AAAA-MM-DD)"
+            id="field-date"
+            registration={register("date")}
+            error={errors.date?.message}
+            type="date"
+          />
+        )}
 
-          {tab === "cuotas" && members && members.length >= 2 && (
-            <div style={{ marginBottom: 14 }}>
-              <div style={{ ...labelCss, marginBottom: 8 }}>¿Quién paga?</div>
-              <div data-testid="payer-selector" style={{ display: "flex", gap: 8 }}>
-                {members.map((m, idx) => {
-                  const person: "a" | "b" = idx === 0 ? "a" : "b";
-                  const isSelected = payerId === m.user_id;
-                  return (
-                    <button
-                      key={m.user_id}
-                      type="button"
-                      data-testid={`payer-option-${m.user_id}`}
-                      onClick={() => setPayerId(m.user_id)}
-                      aria-pressed={isSelected}
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 8,
-                        flex: 1,
-                        padding: "8px 12px",
-                        borderRadius: 10,
-                        border: isSelected
-                          ? "2px solid var(--accent)"
-                          : "1.5px solid var(--border-default)",
-                        background: isSelected
-                          ? "color-mix(in srgb, var(--accent) 10%, transparent)"
-                          : "var(--bg-sunken)",
-                        cursor: "pointer",
-                        transition: "border 150ms, background 150ms",
-                      }}
-                    >
-                      <PersonAvatar
-                        initials={getInitials(m.full_name)}
-                        person={person}
-                        size="sm"
-                      />
-                      <span
-                        style={{
-                          fontSize: 13,
-                          fontWeight: isSelected ? 600 : 400,
-                          color: isSelected ? "var(--accent)" : "var(--fg-1)",
-                          fontFamily: "var(--font-sans)",
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        {m.full_name.split(" ")[0]}
-                      </span>
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-          )}
-
-          {tab === "cuotas" && (
-            <div
-              style={{
-                marginBottom: 14,
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-              }}
-            >
-              <span
+        {tab === "variables" && (
+          <div
+            style={{
+              marginBottom: 14,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
+            <div>
+              <div
                 style={{
                   fontSize: 13,
                   fontWeight: 500,
@@ -540,37 +397,148 @@ export function AddSheet({
                   fontFamily: "var(--font-sans)",
                 }}
               >
-                Renovar automáticamente
-              </span>
-              <Switch
-                checked={autoRenew}
-                onCheckedChange={setAutoRenew}
-                aria-label="Renovación automática"
-              />
+                {isShared ? "Gasto compartido" : "Gasto personal"}
+              </div>
+              <div
+                style={{
+                  fontSize: 11,
+                  color: "var(--fg-3)",
+                  fontFamily: "var(--font-sans)",
+                  marginTop: 2,
+                }}
+              >
+                {isShared
+                  ? "Entra en el balance proporcional"
+                  : "No afecta el balance entre los dos"}
+              </div>
             </div>
-          )}
+            <Switch
+              checked={isShared}
+              onCheckedChange={setIsShared}
+              data-testid="toggle-is-shared"
+              aria-label="Gasto compartido"
+            />
+          </div>
+        )}
 
-          {saveError && (
+        {categories && categories.length > 0 && (
+          <div style={{ marginBottom: 14 }}>
+            <div style={{ ...labelCss, marginBottom: 8 }}>Categoría</div>
+            <CategoryPicker
+              categories={categories}
+              value={categoryId}
+              onChange={setCategoryId}
+            />
+          </div>
+        )}
+
+        {tab === "cuotas" && members && members.length >= 2 && (
+          <div style={{ marginBottom: 14 }}>
+            <div style={{ ...labelCss, marginBottom: 8 }}>¿Quién paga?</div>
             <div
-              role="alert"
+              data-testid="payer-selector"
+              style={{ display: "flex", gap: 8 }}
+            >
+              {members.map((m, idx) => {
+                const person: "a" | "b" = idx === 0 ? "a" : "b";
+                const isSelected = payerId === m.user_id;
+                return (
+                  <button
+                    key={m.user_id}
+                    type="button"
+                    data-testid={`payer-option-${m.user_id}`}
+                    onClick={() => setPayerId(m.user_id)}
+                    aria-pressed={isSelected}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      flex: 1,
+                      padding: "8px 12px",
+                      borderRadius: 10,
+                      border: isSelected
+                        ? "2px solid var(--accent)"
+                        : "1.5px solid var(--border-default)",
+                      background: isSelected
+                        ? "color-mix(in srgb, var(--accent) 10%, transparent)"
+                        : "var(--bg-sunken)",
+                      cursor: "pointer",
+                      transition: "border 150ms, background 150ms",
+                    }}
+                  >
+                    <PersonAvatar
+                      initials={getInitials(m.full_name)}
+                      person={person}
+                      size="sm"
+                    />
+                    <span
+                      style={{
+                        fontSize: 13,
+                        fontWeight: isSelected ? 600 : 400,
+                        color: isSelected ? "var(--accent)" : "var(--fg-1)",
+                        fontFamily: "var(--font-sans)",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {m.full_name.split(" ")[0]}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {tab === "cuotas" && (
+          <div
+            style={{
+              marginBottom: 14,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
+            <span
               style={{
-                ...errorCss,
-                marginBottom: 12,
-                padding: "8px 12px",
-                background: "color-mix(in srgb, var(--status-danger) 10%, transparent)",
-                borderRadius: 8,
-                border: "1px solid var(--status-danger)",
+                fontSize: 13,
+                fontWeight: 500,
+                color: "var(--fg-2)",
+                fontFamily: "var(--font-sans)",
               }}
             >
-              {saveError}
-            </div>
-          )}
+              Renovar automáticamente
+            </span>
+            <Switch
+              checked={autoRenew}
+              onCheckedChange={setAutoRenew}
+              aria-label="Renovación automática"
+            />
+          </div>
+        )}
 
-          <Button type="submit" style={{ width: "100%" }}>
-            Guardar
-          </Button>
-        </form>
-      </SheetContent>
-    </Sheet>
+        {saveError && (
+          <div
+            role="alert"
+            style={{
+              ...errorCss,
+              marginBottom: 12,
+              padding: "8px 12px",
+              background:
+                "color-mix(in srgb, var(--status-danger) 10%, transparent)",
+              borderRadius: 8,
+              border: "1px solid var(--status-danger)",
+            }}
+          >
+            {saveError}
+          </div>
+        )}
+
+        <Button type="submit" style={{ width: "100%" }}>
+          Guardar
+        </Button>
+      </form>
+    </ResponsiveModal>
   );
 }

--- a/src/app/(app)/expenses/page.tsx
+++ b/src/app/(app)/expenses/page.tsx
@@ -121,7 +121,7 @@ function TypeSelectorSheet({
         side="bottom"
         showCloseButton={false}
         aria-describedby={undefined}
-        className="mx-auto w-full sm:max-w-120 rounded-t-[20px] pb-safe-mobile"
+        className="pb-safe-mobile mx-auto w-full rounded-t-[20px] sm:max-w-120"
         style={{
           background: "var(--bg-elevated)",
           border: "none",
@@ -154,13 +154,15 @@ function TypeSelectorSheet({
               key={opt.label}
               data-testid={opt.testId}
               onClick={opt.onSelect}
-              className="flex items-center w-full text-left cursor-pointer rounded-2xl px-4 py-[14px] gap-[14px]"
+              className="flex w-full cursor-pointer items-center gap-[14px] rounded-2xl px-4 py-[14px] text-left"
               style={{
                 background: "var(--bg-sunken)",
                 border: "1.5px solid var(--border-subtle)",
               }}
             >
-              <span aria-hidden="true" style={{ fontSize: 28 }}>{opt.icon}</span>
+              <span aria-hidden="true" style={{ fontSize: 28 }}>
+                {opt.icon}
+              </span>
               <div>
                 <div
                   className="text-[15px] font-semibold"
@@ -216,7 +218,7 @@ function ServiceListSheet({
         side="bottom"
         showCloseButton={false}
         aria-describedby={undefined}
-        className="mx-auto w-full sm:max-w-120 rounded-t-[20px]"
+        className="mx-auto w-full rounded-t-[20px] sm:max-w-120"
         style={{
           background: "var(--bg-elevated)",
           border: "none",
@@ -245,7 +247,7 @@ function ServiceListSheet({
         </SheetHeader>
 
         <div
-          className="flex flex-col rounded-2xl overflow-hidden"
+          className="flex flex-col overflow-hidden rounded-2xl"
           style={{
             gap: 1,
             background: "var(--bg-sunken)",
@@ -254,7 +256,7 @@ function ServiceListSheet({
         >
           {instances.length === 0 && (
             <div
-              className="text-[13px] text-center"
+              className="text-center text-[13px]"
               style={{
                 padding: "20px 16px",
                 color: "var(--fg-3)",
@@ -270,7 +272,7 @@ function ServiceListSheet({
               <button
                 key={fi.id}
                 onClick={() => onPickInstance(fi.id)}
-                className="flex items-center justify-between gap-3 px-4 py-3 w-full text-left cursor-pointer"
+                className="flex w-full cursor-pointer items-center justify-between gap-3 px-4 py-3 text-left"
                 style={{
                   background: "var(--bg-elevated)",
                   border: "none",
@@ -303,7 +305,7 @@ function ServiceListSheet({
                 </div>
                 {fi.paid && (
                   <span
-                    className="text-xs font-semibold flex-shrink-0 rounded-[6px] px-2 py-[2px]"
+                    className="flex-shrink-0 rounded-[6px] px-2 py-[2px] text-xs font-semibold"
                     style={{
                       color: "var(--color-teal)",
                       background:
@@ -321,7 +323,7 @@ function ServiceListSheet({
 
         <button
           onClick={onCreateNew}
-          className="flex items-center justify-center gap-2 mt-3 w-full text-sm font-semibold rounded-2xl cursor-pointer"
+          className="mt-3 flex w-full cursor-pointer items-center justify-center gap-2 rounded-2xl text-sm font-semibold"
           style={{
             padding: "13px 16px",
             background: "transparent",
@@ -400,7 +402,7 @@ function EditServiceSheet({
         side="bottom"
         showCloseButton={false}
         aria-describedby={undefined}
-        className="mx-auto w-full sm:max-w-120 rounded-t-[20px]"
+        className="mx-auto w-full rounded-t-[20px] sm:max-w-120"
         style={{
           background: "var(--bg-elevated)",
           border: "none",
@@ -432,7 +434,7 @@ function EditServiceSheet({
         <div className="mb-[14px]">
           <label
             htmlFor="edit-service-amount"
-            className="block text-[13px] font-medium mb-[5px]"
+            className="mb-[5px] block text-[13px] font-medium"
             style={{
               color: "var(--fg-2)",
               fontFamily: "var(--font-sans)",
@@ -481,7 +483,7 @@ function EditServiceSheet({
           </div>
           {instance.amount_override == null && (
             <div
-              className="text-xs mt-1"
+              className="mt-1 text-xs"
               style={{
                 color: "var(--fg-3)",
                 fontFamily: "var(--font-sans)",
@@ -493,7 +495,7 @@ function EditServiceSheet({
           {fieldError && (
             <div
               role="alert"
-              className="text-xs mt-1"
+              className="mt-1 text-xs"
               style={{
                 color: "var(--status-danger)",
                 fontFamily: "var(--font-sans)",
@@ -521,7 +523,9 @@ function EditServiceSheet({
               toggleMutation.mutate({ id: instance.id, paid: checked })
             }
             disabled={isPending}
-            aria-label={instance.paid ? "Marcar como no pagado" : "Marcar como pagado"}
+            aria-label={
+              instance.paid ? "Marcar como no pagado" : "Marcar como pagado"
+            }
           />
         </div>
 
@@ -588,14 +592,20 @@ export default function ExpensesPage() {
     payerId?: string | null,
   ) {
     setFlow({ step: "idle" });
-    save(fields, categoryId, autoRenew, requiresMonthlyReview, isShared, payerId);
+    save(
+      fields,
+      categoryId,
+      autoRenew,
+      requiresMonthlyReview,
+      isShared,
+      payerId,
+    );
   }
 
   const queryClient = useQueryClient();
 
   const confirmAllMutation = useMutation({
-    mutationFn: () =>
-      confirmAllFixedExpenseInstances(coupleId!, month),
+    mutationFn: () => confirmAllFixedExpenseInstances(coupleId!, month),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["monthly-data"] });
     },
@@ -647,80 +657,84 @@ export default function ExpensesPage() {
             paddingTop: 14,
           }}
         >
-          <h1
-            className="text-lg font-bold px-5 pb-[10px] m-0"
-            style={{
-              color: "var(--fg-1)",
-              fontFamily: "var(--font-sans)",
-            }}
-          >
-            Gastos
-          </h1>
-          <div className="px-4 pb-2.5">
-            <TabsList className="w-full bg-(--bg-sunken)">
-              {(["cuotas", "fijos", "variables"] as Tab[]).map((t) => (
-                <TabsTrigger
-                  key={t}
-                  value={t}
-                  data-testid={TAB_TESTID[t]}
-                  className="flex-1 text-(--fg-2) data-[state=active]:bg-(--bg-elevated) data-[state=active]:font-semibold data-[state=active]:text-(--accent) data-[state=active]:shadow-sm"
-                >
-                  {TAB_LABEL[t]}
-                </TabsTrigger>
-              ))}
-            </TabsList>
-          </div>
-          <TabDescription tab={tab} />
-          {categories.length > 0 && (
-            <div className="flex overflow-x-auto gap-1.5 px-4 pt-2 pb-2.5 [scrollbar-width:none]">
-              <button
-                onClick={() => setFilterCategory(null)}
-                className="flex-shrink-0 text-xs font-semibold cursor-pointer rounded-[20px]"
-                style={{
-                  padding: "4px 12px",
-                  border: "1px solid var(--border-subtle)",
-                  background:
-                    filterCategory === null
-                      ? "var(--accent)"
-                      : "var(--bg-sunken)",
-                  color: filterCategory === null ? "#fff" : "var(--fg-2)",
-                  fontFamily: "var(--font-sans)",
-                }}
-              >
-                Todos
-              </button>
-              {categories.map((cat) => (
+          <div className="mx-auto w-full max-w-3xl">
+            <h1
+              className="m-0 px-5 pb-[10px] text-lg font-bold"
+              style={{
+                color: "var(--fg-1)",
+                fontFamily: "var(--font-sans)",
+              }}
+            >
+              Gastos
+            </h1>
+            <div className="px-4 pb-2.5">
+              <TabsList className="w-full bg-(--bg-sunken)">
+                {(["cuotas", "fijos", "variables"] as Tab[]).map((t) => (
+                  <TabsTrigger
+                    key={t}
+                    value={t}
+                    data-testid={TAB_TESTID[t]}
+                    className="flex-1 text-(--fg-2) data-[state=active]:bg-(--bg-elevated) data-[state=active]:font-semibold data-[state=active]:text-(--accent) data-[state=active]:shadow-sm"
+                  >
+                    {TAB_LABEL[t]}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </div>
+            <TabDescription tab={tab} />
+            {categories.length > 0 && (
+              <div className="flex gap-1.5 overflow-x-auto px-4 pt-2 pb-2.5 [scrollbar-width:none]">
                 <button
-                  key={cat.id}
-                  onClick={() =>
-                    setFilterCategory(filterCategory === cat.id ? null : cat.id)
-                  }
-                  className="flex-shrink-0 text-xs font-semibold cursor-pointer rounded-[20px]"
+                  onClick={() => setFilterCategory(null)}
+                  className="flex-shrink-0 cursor-pointer rounded-[20px] text-xs font-semibold"
                   style={{
                     padding: "4px 12px",
                     border: "1px solid var(--border-subtle)",
                     background:
-                      filterCategory === cat.id
+                      filterCategory === null
                         ? "var(--accent)"
                         : "var(--bg-sunken)",
-                    color: filterCategory === cat.id ? "#fff" : "var(--fg-2)",
+                    color: filterCategory === null ? "#fff" : "var(--fg-2)",
                     fontFamily: "var(--font-sans)",
                   }}
                 >
-                  {cat.icon} {cat.name}
+                  Todos
                 </button>
-              ))}
-            </div>
-          )}
+                {categories.map((cat) => (
+                  <button
+                    key={cat.id}
+                    onClick={() =>
+                      setFilterCategory(
+                        filterCategory === cat.id ? null : cat.id,
+                      )
+                    }
+                    className="flex-shrink-0 cursor-pointer rounded-[20px] text-xs font-semibold"
+                    style={{
+                      padding: "4px 12px",
+                      border: "1px solid var(--border-subtle)",
+                      background:
+                        filterCategory === cat.id
+                          ? "var(--accent)"
+                          : "var(--bg-sunken)",
+                      color: filterCategory === cat.id ? "#fff" : "var(--fg-2)",
+                      fontFamily: "var(--font-sans)",
+                    }}
+                  >
+                    {cat.icon} {cat.name}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
 
         <div style={{ flex: 1, overflowY: "auto" }}>
           {/* CUOTAS */}
           <TabsContent value="cuotas" className="mt-0">
-            <div className="px-4 py-3 flex flex-col gap-2">
+            <div className="mx-auto flex w-full max-w-3xl flex-col gap-2 px-4 py-3">
               {cuotas.length === 0 && (
                 <div
-                  className="text-center text-sm py-12"
+                  className="py-12 text-center text-sm"
                   style={{
                     color: "var(--fg-3)",
                     fontFamily: "var(--font-sans)",
@@ -729,7 +743,7 @@ export default function ExpensesPage() {
                   Sin compras en cuotas. Usá el + para agregar.
                 </div>
               )}
-              <ul className="list-none m-0 p-0 flex flex-col gap-2">
+              <ul className="m-0 flex list-none flex-col gap-2 p-0">
                 {cuotas.map((c) => (
                   <li key={c.id}>
                     <CuotaItem
@@ -745,7 +759,7 @@ export default function ExpensesPage() {
 
           {/* FIJOS */}
           <TabsContent value="fijos" className="mt-0">
-            <div style={{ padding: "12px 16px" }}>
+            <div className="mx-auto w-full max-w-3xl px-4 py-3">
               {fijos.length === 0 && (
                 <div
                   className="text-center text-sm"
@@ -784,7 +798,7 @@ export default function ExpensesPage() {
                     </div>
                   )}
                   <ul
-                    className="list-none m-0 p-0 flex flex-col rounded-2xl overflow-hidden"
+                    className="m-0 flex list-none flex-col overflow-hidden rounded-2xl p-0"
                     style={{
                       gap: 1,
                       background: "var(--bg-elevated)",
@@ -804,7 +818,7 @@ export default function ExpensesPage() {
                     ))}
                   </ul>
                   <div
-                    className="flex justify-between rounded-xl px-4 py-3 mt-2"
+                    className="mt-2 flex justify-between rounded-xl px-4 py-3"
                     style={{
                       background: "var(--bg-elevated)",
                       border: "1px solid var(--border-subtle)",
@@ -842,7 +856,7 @@ export default function ExpensesPage() {
 
           {/* VARIABLES */}
           <TabsContent value="variables" className="mt-0">
-            <div className="px-4 py-3 flex flex-col gap-2">
+            <div className="mx-auto flex w-full max-w-3xl flex-col gap-2 px-4 py-3">
               {variables.length === 0 && (
                 <div
                   className="text-center text-sm"
@@ -855,7 +869,7 @@ export default function ExpensesPage() {
                   Sin gastos variables. Usá el + para agregar.
                 </div>
               )}
-              <ul className="list-none m-0 p-0 flex flex-col gap-2">
+              <ul className="m-0 flex list-none flex-col gap-2 p-0">
                 {variables.map((v) => (
                   <li key={v.id}>
                     <VariableItem

--- a/src/app/(app)/expenses/page.tsx
+++ b/src/app/(app)/expenses/page.tsx
@@ -23,15 +23,10 @@ import { FijoItem } from "./_components/fijo-item";
 import { VariableItem } from "./_components/variable-item";
 import { TAB_LABEL, TAB_TESTID } from "./_components/segmented-control";
 import { AddSheet } from "./_components/add-sheet";
+import { ResponsiveModal } from "@/components/shared/responsive-modal";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
 
 const TAB_DESCRIPTIONS: Record<Tab, string> = {
   cuotas: "Compras en cuotas o planes de pago recurrentes",
@@ -115,81 +110,53 @@ function TypeSelectorSheet({
   ];
 
   return (
-    <Sheet open onOpenChange={(open) => !open && onClose()}>
-      <SheetContent
-        data-testid="type-selector-sheet"
-        side="bottom"
-        showCloseButton={false}
-        aria-describedby={undefined}
-        className="pb-safe-mobile mx-auto w-full rounded-t-[20px] sm:max-w-120"
-        style={{
-          background: "var(--bg-elevated)",
-          border: "none",
-          padding: "20px 20px 0",
-        }}
-      >
-        <div
-          style={{
-            width: 36,
-            height: 4,
-            borderRadius: 99,
-            background: "var(--border-default)",
-            margin: "0 auto 20px",
-          }}
-        />
-        <SheetHeader className="mb-5">
-          <SheetTitle
-            className="text-lg font-bold"
+    <ResponsiveModal
+      open
+      onOpenChange={(open) => !open && onClose()}
+      title="¿Qué querés agregar?"
+      data-testid="type-selector-sheet"
+    >
+      <div className="flex flex-col gap-2.5 pb-4">
+        {options.map((opt) => (
+          <button
+            key={opt.label}
+            data-testid={opt.testId}
+            onClick={opt.onSelect}
+            className="flex w-full cursor-pointer items-center gap-3.5 rounded-2xl px-4 py-3.5 text-left"
             style={{
-              color: "var(--fg-1)",
-              fontFamily: "var(--font-sans)",
+              background: "var(--bg-sunken)",
+              border: "1.5px solid var(--border-subtle)",
             }}
           >
-            ¿Qué querés agregar?
-          </SheetTitle>
-        </SheetHeader>
-        <div className="flex flex-col gap-[10px]">
-          {options.map((opt) => (
-            <button
-              key={opt.label}
-              data-testid={opt.testId}
-              onClick={opt.onSelect}
-              className="flex w-full cursor-pointer items-center gap-[14px] rounded-2xl px-4 py-[14px] text-left"
-              style={{
-                background: "var(--bg-sunken)",
-                border: "1.5px solid var(--border-subtle)",
-              }}
-            >
-              <span aria-hidden="true" style={{ fontSize: 28 }}>
-                {opt.icon}
-              </span>
-              <div>
-                <div
-                  className="text-[15px] font-semibold"
-                  style={{
-                    color: "var(--fg-1)",
-                    fontFamily: "var(--font-sans)",
-                  }}
-                >
-                  {opt.label}
-                </div>
-                <div
-                  className="text-xs"
-                  style={{
-                    color: "var(--fg-3)",
-                    marginTop: 2,
-                    fontFamily: "var(--font-sans)",
-                    lineHeight: 1.4,
-                  }}
-                >
-                  {opt.description}
-                </div>
+            <span aria-hidden="true" style={{ fontSize: 28 }}>
+              {opt.icon}
+            </span>
+            <div>
+              <div
+                className="text-[15px] font-semibold"
+                style={{
+                  color: "var(--fg-1)",
+                  fontFamily: "var(--font-sans)",
+                }}
+              >
+                {opt.label}
               </div>
-            </button>
-          ))}
-        </div>
-      </SheetContent>
-    </Sheet>
+              <div
+                className="text-xs"
+                style={{
+                  color: "var(--fg-3)",
+                  marginTop: 2,
+                  fontFamily: "var(--font-sans)",
+                  lineHeight: 1.4,
+                }}
+              >
+                {opt.description}
+              </div>
+            </div>
+          </button>
+        ))}
+      </div>
+    </ResponsiveModal>
   );
 }
 
@@ -212,130 +179,101 @@ function ServiceListSheet({
   onClose,
 }: ServiceListSheetProps) {
   return (
-    <Sheet open onOpenChange={(open) => !open && onClose()}>
-      <SheetContent
-        data-testid="service-list-sheet"
-        side="bottom"
-        showCloseButton={false}
-        aria-describedby={undefined}
-        className="mx-auto w-full rounded-t-[20px] sm:max-w-120"
+    <ResponsiveModal
+      open
+      onOpenChange={(open) => !open && onClose()}
+      title="Servicios del mes"
+      data-testid="service-list-sheet"
+    >
+      <div
+        className="flex flex-col overflow-hidden rounded-2xl"
         style={{
-          background: "var(--bg-elevated)",
-          border: "none",
-          padding: "20px 20px 40px",
+          gap: 1,
+          background: "var(--bg-sunken)",
+          border: "1px solid var(--border-subtle)",
         }}
       >
-        <div
-          style={{
-            width: 36,
-            height: 4,
-            borderRadius: 99,
-            background: "var(--border-default)",
-            margin: "0 auto 20px",
-          }}
-        />
-        <SheetHeader className="mb-4">
-          <SheetTitle
-            className="text-lg font-bold"
+        {instances.length === 0 && (
+          <div
+            className="text-center text-[13px]"
             style={{
-              color: "var(--fg-1)",
+              padding: "20px 16px",
+              color: "var(--fg-3)",
               fontFamily: "var(--font-sans)",
             }}
           >
-            Servicios del mes
-          </SheetTitle>
-        </SheetHeader>
-
-        <div
-          className="flex flex-col overflow-hidden rounded-2xl"
-          style={{
-            gap: 1,
-            background: "var(--bg-sunken)",
-            border: "1px solid var(--border-subtle)",
-          }}
-        >
-          {instances.length === 0 && (
-            <div
-              className="text-center text-[13px]"
+            Sin servicios este mes
+          </div>
+        )}
+        {instances.map((fi) => {
+          const amount = effectiveFixedAmount(fi);
+          return (
+            <button
+              key={fi.id}
+              onClick={() => onPickInstance(fi.id)}
+              className="flex w-full cursor-pointer items-center justify-between gap-3 px-4 py-3 text-left"
               style={{
-                padding: "20px 16px",
-                color: "var(--fg-3)",
-                fontFamily: "var(--font-sans)",
+                background: "var(--bg-elevated)",
+                border: "none",
+                borderBottom: "1px solid var(--border-subtle)",
               }}
             >
-              Sin servicios este mes
-            </div>
-          )}
-          {instances.map((fi) => {
-            const amount = effectiveFixedAmount(fi);
-            return (
-              <button
-                key={fi.id}
-                onClick={() => onPickInstance(fi.id)}
-                className="flex w-full cursor-pointer items-center justify-between gap-3 px-4 py-3 text-left"
-                style={{
-                  background: "var(--bg-elevated)",
-                  border: "none",
-                  borderBottom: "1px solid var(--border-subtle)",
-                }}
-              >
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div
-                    className="text-sm font-medium"
-                    style={{
-                      color: "var(--fg-1)",
-                      fontFamily: "var(--font-sans)",
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                      whiteSpace: "nowrap",
-                    }}
-                  >
-                    {fi.fixed_expense_templates.description}
-                  </div>
-                  <div
-                    className="text-xs"
-                    style={{
-                      color: "var(--fg-3)",
-                      fontFamily: "var(--font-mono)",
-                      marginTop: 2,
-                    }}
-                  >
-                    {formatARS(amount)}
-                  </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div
+                  className="text-sm font-medium"
+                  style={{
+                    color: "var(--fg-1)",
+                    fontFamily: "var(--font-sans)",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {fi.fixed_expense_templates.description}
                 </div>
-                {fi.paid && (
-                  <span
-                    className="flex-shrink-0 rounded-[6px] px-2 py-[2px] text-xs font-semibold"
-                    style={{
-                      color: "var(--color-teal)",
-                      background:
-                        "color-mix(in srgb, var(--color-teal) 12%, transparent)",
-                      fontFamily: "var(--font-sans)",
-                    }}
-                  >
-                    ✓ Pagado
-                  </span>
-                )}
-              </button>
-            );
-          })}
-        </div>
+                <div
+                  className="text-xs"
+                  style={{
+                    color: "var(--fg-3)",
+                    fontFamily: "var(--font-mono)",
+                    marginTop: 2,
+                  }}
+                >
+                  {formatARS(amount)}
+                </div>
+              </div>
+              {fi.paid && (
+                <span
+                  className="shrink-0 rounded-md px-2 py-0.5 text-xs font-semibold"
+                  style={{
+                    color: "var(--color-teal)",
+                    background:
+                      "color-mix(in srgb, var(--color-teal) 12%, transparent)",
+                    fontFamily: "var(--font-sans)",
+                  }}
+                >
+                  ✓ Pagado
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
 
-        <button
-          onClick={onCreateNew}
-          className="mt-3 flex w-full cursor-pointer items-center justify-center gap-2 rounded-2xl text-sm font-semibold"
-          style={{
-            padding: "13px 16px",
-            background: "transparent",
-            border: "1.5px dashed var(--border-default)",
-            color: "var(--accent)",
-            fontFamily: "var(--font-sans)",
-          }}
-        >
-          + Nuevo servicio
-        </button>
-      </SheetContent>
-    </Sheet>
+      <button
+        onClick={onCreateNew}
+        className="mt-3 flex w-full cursor-pointer items-center justify-center gap-2 rounded-2xl text-sm font-semibold"
+        style={{
+          padding: "13px 16px",
+          background: "transparent",
+          border: "1.5px dashed var(--border-default)",
+          color: "var(--accent)",
+          fontFamily: "var(--font-sans)",
+        }}
+      >
+        + Nuevo servicio
+      </button>
+    </ResponsiveModal>
   );
 }
 
@@ -396,150 +334,112 @@ function EditServiceSheet({
   const name = instance.fixed_expense_templates.description;
 
   return (
-    <Sheet open onOpenChange={(open) => !open && onClose()}>
-      <SheetContent
-        data-testid="edit-service-sheet"
-        side="bottom"
-        showCloseButton={false}
-        aria-describedby={undefined}
-        className="mx-auto w-full rounded-t-[20px] sm:max-w-120"
-        style={{
-          background: "var(--bg-elevated)",
-          border: "none",
-          padding: "20px 20px 40px",
-        }}
-      >
+    <ResponsiveModal
+      open
+      onOpenChange={(open) => !open && onClose()}
+      title={name}
+      data-testid="edit-service-sheet"
+    >
+      {/* Amount edit */}
+      <div className="mb-3.5">
+        <label
+          htmlFor="edit-service-amount"
+          className="mb-1.5 block text-[13px] font-medium"
+          style={{ color: "var(--fg-2)", fontFamily: "var(--font-sans)" }}
+        >
+          Monto este mes
+        </label>
         <div
+          className="flex items-center overflow-hidden"
           style={{
-            width: 36,
-            height: 4,
-            borderRadius: 99,
-            background: "var(--border-default)",
-            margin: "0 auto 20px",
+            background: "var(--bg-sunken)",
+            borderRadius: 10,
+            border: "1.5px solid var(--border-default)",
           }}
-        />
-        <SheetHeader className="mb-4">
-          <SheetTitle
-            className="text-lg font-bold"
-            style={{
-              color: "var(--fg-1)",
-              fontFamily: "var(--font-sans)",
-            }}
-          >
-            {name}
-          </SheetTitle>
-        </SheetHeader>
-
-        {/* Amount edit */}
-        <div className="mb-[14px]">
-          <label
-            htmlFor="edit-service-amount"
-            className="mb-[5px] block text-[13px] font-medium"
-            style={{
-              color: "var(--fg-2)",
-              fontFamily: "var(--font-sans)",
-            }}
-          >
-            Monto este mes
-          </label>
-          <div
-            className="flex items-center overflow-hidden"
-            style={{
-              background: "var(--bg-sunken)",
-              borderRadius: 10,
-              border: "1.5px solid var(--border-default)",
-            }}
-          >
-            <span
-              aria-hidden
-              className="text-base font-semibold"
-              style={{
-                padding: "10px 6px 10px 12px",
-                color: "var(--fg-3)",
-                fontFamily: "var(--font-mono)",
-              }}
-            >
-              $
-            </span>
-            <input
-              id="edit-service-amount"
-              type="text"
-              value={draft}
-              onChange={(e) => {
-                setDraft(e.target.value);
-                setFieldError(null);
-              }}
-              inputMode="decimal"
-              className="flex-1 text-base font-semibold"
-              style={{
-                border: "none",
-                background: "transparent",
-                padding: "10px 12px 10px 4px",
-                fontFamily: "var(--font-mono)",
-                outline: "none",
-                color: "var(--fg-1)",
-              }}
-            />
-          </div>
-          {instance.amount_override == null && (
-            <div
-              className="mt-1 text-xs"
-              style={{
-                color: "var(--fg-3)",
-                fontFamily: "var(--font-sans)",
-              }}
-            >
-              Default: {formatARS(instance.fixed_expense_templates.amount)}
-            </div>
-          )}
-          {fieldError && (
-            <div
-              role="alert"
-              className="mt-1 text-xs"
-              style={{
-                color: "var(--status-danger)",
-                fontFamily: "var(--font-sans)",
-              }}
-            >
-              {fieldError}
-            </div>
-          )}
-        </div>
-
-        {/* Paid toggle */}
-        <div className="mb-5 flex items-center justify-between">
+        >
           <span
-            className="text-[13px] font-medium"
+            aria-hidden
+            className="text-base font-semibold"
             style={{
-              color: "var(--fg-2)",
-              fontFamily: "var(--font-sans)",
+              padding: "10px 6px 10px 12px",
+              color: "var(--fg-3)",
+              fontFamily: "var(--font-mono)",
             }}
           >
-            Ya lo pagué
+            $
           </span>
-          <Switch
-            checked={instance.paid}
-            onCheckedChange={(checked) =>
-              toggleMutation.mutate({ id: instance.id, paid: checked })
-            }
-            disabled={isPending}
-            aria-label={
-              instance.paid ? "Marcar como no pagado" : "Marcar como pagado"
-            }
+          <input
+            id="edit-service-amount"
+            type="text"
+            value={draft}
+            onChange={(e) => {
+              setDraft(e.target.value);
+              setFieldError(null);
+            }}
+            inputMode="decimal"
+            className="flex-1 text-base font-semibold"
+            style={{
+              border: "none",
+              background: "transparent",
+              padding: "10px 12px 10px 4px",
+              fontFamily: "var(--font-mono)",
+              outline: "none",
+              color: "var(--fg-1)",
+            }}
           />
         </div>
+        {instance.amount_override == null && (
+          <div
+            className="mt-1 text-xs"
+            style={{ color: "var(--fg-3)", fontFamily: "var(--font-sans)" }}
+          >
+            Default: {formatARS(instance.fixed_expense_templates.amount)}
+          </div>
+        )}
+        {fieldError && (
+          <div
+            role="alert"
+            className="mt-1 text-xs"
+            style={{
+              color: "var(--status-danger)",
+              fontFamily: "var(--font-sans)",
+            }}
+          >
+            {fieldError}
+          </div>
+        )}
+      </div>
 
-        <Button
-          type="button"
-          onClick={handleSave}
-          disabled={isPending}
-          className="w-full"
-          style={{ opacity: isPending ? 0.7 : 1 }}
+      {/* Paid toggle */}
+      <div className="mb-5 flex items-center justify-between">
+        <span
+          className="text-[13px] font-medium"
+          style={{ color: "var(--fg-2)", fontFamily: "var(--font-sans)" }}
         >
-          Guardar
-        </Button>
-      </SheetContent>
-    </Sheet>
+          Ya lo pagué
+        </span>
+        <Switch
+          checked={instance.paid}
+          onCheckedChange={(checked) =>
+            toggleMutation.mutate({ id: instance.id, paid: checked })
+          }
+          disabled={isPending}
+          aria-label={
+            instance.paid ? "Marcar como no pagado" : "Marcar como pagado"
+          }
+        />
+      </div>
+
+      <Button
+        type="button"
+        onClick={handleSave}
+        disabled={isPending}
+        className="w-full"
+        style={{ opacity: isPending ? 0.7 : 1 }}
+      >
+        Guardar
+      </Button>
+    </ResponsiveModal>
   );
 }
 

--- a/src/app/(app)/history/_components/month-detail.tsx
+++ b/src/app/(app)/history/_components/month-detail.tsx
@@ -82,6 +82,7 @@ export function MonthDetail({
         <Badge variant="neutral">Solo lectura</Badge>
       </div>
       <div
+        className="mx-auto w-full max-w-3xl"
         style={{
           flex: 1,
           padding: "16px",

--- a/src/app/(app)/history/page.tsx
+++ b/src/app/(app)/history/page.tsx
@@ -77,6 +77,7 @@ export default function HistoryPage() {
         )}
       </div>
       <div
+        className="mx-auto w-full max-w-3xl"
         style={{
           flex: 1,
           padding: "12px 16px",

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -101,8 +101,14 @@ export default function SettingsPage() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center" style={{ minHeight: "100%" }}>
-        <span className="text-sm" style={{ color: "var(--fg-3)", fontFamily: "var(--font-sans)" }}>
+      <div
+        className="flex items-center justify-center"
+        style={{ minHeight: "100%" }}
+      >
+        <span
+          className="text-sm"
+          style={{ color: "var(--fg-3)", fontFamily: "var(--font-sans)" }}
+        >
           Cargando...
         </span>
       </div>
@@ -122,20 +128,18 @@ export default function SettingsPage() {
         }}
       >
         <h1
-          className="text-xl font-bold m-0"
+          className="m-0 text-xl font-bold"
           style={{ color: "var(--fg-1)", fontFamily: "var(--font-sans)" }}
         >
           Configuración
         </h1>
       </div>
 
-      <div
-        className="flex-1 p-4 flex flex-col gap-4"
-      >
+      <div className="mx-auto flex w-full max-w-xl flex-1 flex-col gap-4 p-4">
         {/* Pareja */}
         <section>
           <h2
-            className="text-xs font-semibold mb-2 uppercase"
+            className="mb-2 text-xs font-semibold uppercase"
             style={{
               color: "var(--fg-3)",
               letterSpacing: "0.05em",
@@ -155,7 +159,7 @@ export default function SettingsPage() {
           >
             {member ? (
               <>
-                <div className="p-4 flex gap-3 items-center">
+                <div className="flex items-center gap-3 p-4">
                   <div className="flex shrink-0">
                     <Avatar
                       initials={
@@ -195,7 +199,10 @@ export default function SettingsPage() {
                     </div>
                     <div
                       className="text-xs"
-                      style={{ color: "var(--fg-3)", fontFamily: "var(--font-sans)" }}
+                      style={{
+                        color: "var(--fg-3)",
+                        fontFamily: "var(--font-sans)",
+                      }}
                     >
                       {member.couples?.status === "PENDING"
                         ? "⏳ Invitación pendiente"
@@ -212,7 +219,7 @@ export default function SettingsPage() {
                     }}
                   >
                     <div
-                      className="font-semibold mb-2"
+                      className="mb-2 font-semibold"
                       style={{
                         fontSize: 13,
                         color: "var(--fg-1)",
@@ -249,10 +256,7 @@ export default function SettingsPage() {
                       </div>
                     ) : (
                       <>
-                        <form
-                          onSubmit={handleInvite}
-                          className="flex gap-2"
-                        >
+                        <form onSubmit={handleInvite} className="flex gap-2">
                           <Input
                             type="email"
                             value={inviteEmail}
@@ -305,7 +309,7 @@ export default function SettingsPage() {
         {member && (
           <section>
             <h2
-              className="text-xs font-semibold mb-2 uppercase"
+              className="mb-2 text-xs font-semibold uppercase"
               style={{
                 color: "var(--fg-3)",
                 letterSpacing: "0.05em",
@@ -333,7 +337,7 @@ export default function SettingsPage() {
                   }}
                 >
                   <span
-                    className="font-semibold text-base"
+                    className="text-base font-semibold"
                     style={{
                       padding: "10px 6px 10px 12px",
                       color: "var(--fg-3)",
@@ -349,7 +353,7 @@ export default function SettingsPage() {
                     onChange={(e) => setMyIncome(e.target.value)}
                     inputMode="decimal"
                     placeholder="0"
-                    className="flex-1 border-none bg-transparent text-base font-semibold outline-none py-2.5 pl-1 pr-3"
+                    className="flex-1 border-none bg-transparent py-2.5 pr-3 pl-1 text-base font-semibold outline-none"
                     style={{
                       fontFamily: "var(--font-mono)",
                       color: "var(--fg-1)",
@@ -395,7 +399,7 @@ export default function SettingsPage() {
         {/* Cuenta */}
         <section>
           <h2
-            className="text-xs font-semibold mb-2 uppercase"
+            className="mb-2 text-xs font-semibold uppercase"
             style={{
               color: "var(--fg-3)",
               letterSpacing: "0.05em",
@@ -427,7 +431,11 @@ export default function SettingsPage() {
                 Moneda
               </span>
               <span
-                style={{ fontSize: 13, color: "var(--fg-2)", fontFamily: "var(--font-sans)" }}
+                style={{
+                  fontSize: 13,
+                  color: "var(--fg-2)",
+                  fontFamily: "var(--font-sans)",
+                }}
               >
                 ARS — Peso argentino
               </span>
@@ -435,7 +443,7 @@ export default function SettingsPage() {
             <Button
               variant="ghost"
               onClick={handleSignOut}
-              className="w-full justify-start text-sm font-medium rounded-none"
+              className="w-full justify-start rounded-none text-sm font-medium"
               style={{
                 padding: "14px 16px",
                 color: "var(--status-danger)",

--- a/src/components/shared/responsive-modal.tsx
+++ b/src/components/shared/responsive-modal.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import * as React from "react";
+import { Dialog as DialogPrimitive } from "radix-ui";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useIsMobile } from "@/lib/hooks/use-mobile";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+
+interface ResponsiveModalProps {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly title: string;
+  readonly children: React.ReactNode;
+  readonly "data-testid"?: string;
+}
+
+export function ResponsiveModal({
+  open,
+  onOpenChange,
+  title,
+  children,
+  "data-testid": testId,
+}: ResponsiveModalProps) {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return (
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        <SheetContent
+          side="bottom"
+          showCloseButton={false}
+          aria-describedby={undefined}
+          data-testid={testId}
+          className="pb-safe-mobile mx-auto w-full max-w-120 rounded-t-[20px]"
+          style={{
+            background: "var(--bg-elevated)",
+            border: "none",
+            padding: "20px 20px 0",
+          }}
+        >
+          <div
+            aria-hidden
+            style={{
+              width: 36,
+              height: 4,
+              borderRadius: 99,
+              background: "var(--border-default)",
+              margin: "0 auto 20px",
+            }}
+          />
+          <SheetHeader style={{ marginBottom: 16 }}>
+            <SheetTitle
+              style={{
+                fontSize: 18,
+                fontWeight: 700,
+                color: "var(--fg-1)",
+                fontFamily: "var(--font-sans)",
+              }}
+            >
+              {title}
+            </SheetTitle>
+          </SheetHeader>
+          {children}
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay
+          className={cn(
+            "fixed inset-0 z-50 bg-black/50",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out",
+            "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+          )}
+        />
+        <DialogPrimitive.Content
+          aria-describedby={undefined}
+          data-testid={testId}
+          className={cn(
+            "fixed top-1/2 left-1/2 z-50 -translate-x-1/2 -translate-y-1/2",
+            "w-full max-w-120 overflow-y-auto rounded-2xl",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out",
+            "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+            "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+          )}
+          style={{
+            background: "var(--bg-elevated)",
+            border: "1px solid var(--border-subtle)",
+            boxShadow: "0 20px 60px rgba(0,0,0,0.18)",
+            padding: "28px 24px 32px",
+            maxHeight: "85vh",
+          }}
+        >
+          <DialogPrimitive.Close
+            className="absolute top-4 right-4 rounded-md opacity-60 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-none"
+            style={{ color: "var(--fg-2)" }}
+            aria-label="Cerrar"
+          >
+            <X size={18} />
+          </DialogPrimitive.Close>
+          <DialogPrimitive.Title
+            style={{
+              fontSize: 18,
+              fontWeight: 700,
+              color: "var(--fg-1)",
+              fontFamily: "var(--font-sans)",
+              marginBottom: 20,
+              paddingRight: 28,
+            }}
+          >
+            {title}
+          </DialogPrimitive.Title>
+          {children}
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}


### PR DESCRIPTION
## Summary

- Add `max-w-xl mx-auto` on Settings page content — form sections were spanning ~1100px at 1366px
- Add `max-w-3xl mx-auto` on History list and MonthDetail content — month cards were stretching the full content area
- Add `max-w-3xl mx-auto` on Expenses header (title + tabs + category pills) and each TabsContent list — both the tab bar and list items were stretching full width

The `bg-elevated` header bars remain full-width (intentional); only the inner content is constrained. Mobile is unaffected — all max-widths exceed mobile viewport width.

## Changes

| File | Change |
|------|--------|
| `src/app/(app)/settings/page.tsx` | `max-w-xl` on the content sections wrapper |
| `src/app/(app)/history/page.tsx` | `max-w-3xl` on the month list wrapper |
| `src/app/(app)/history/_components/month-detail.tsx` | `max-w-3xl` on the detail content wrapper |
| `src/app/(app)/expenses/page.tsx` | `max-w-3xl` on header inner div + each TabsContent list div |

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] 255 unit tests pass
- [x] 11 a11y tests pass (mobile layout unchanged)