### PR TITLE
chore: ignore Claude agent artifacts, audit screenshots and ad-hoc scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,19 @@ next-env.d.ts
 # GGA (Gentleman Guardian Angel) AI code review config
 .gga
 
+# Claude Code / AI agent artifacts
+.claude/worktrees/
+.claude/scheduled_tasks.lock
+.playwright-mcp/
+*.worktree
+
+# Audit screenshots dumped in root
+/*.png
+
+# Ad-hoc scripts and test reports
+/qacito_tests/
+/scripts/
+
 # Serwist generated service worker
 /public/sw.js
 


### PR DESCRIPTION
## Summary
- Agrega entradas al `.gitignore` para artefactos generados por el agente Claude y sesiones de auditoría que no deben versionarse

## Changes
| File | Change |
|------|--------|
| `.gitignore` | Ignora `.claude/worktrees/`, `.claude/scheduled_tasks.lock`, `.playwright-mcp/`, `*.worktree`, `/*.png`, `/qacito_tests/`, `/scripts/` |

## Test plan
- [x] `git status` limpio después de eliminar los archivos
- [x] Verificado que las entradas no afectan archivos legítimos del repo