### PR TITLE
ci: apply Supabase migrations before Vercel deploy on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,6 +30,18 @@ jobs:
         with:
           node-version: 20
 
+      - name: Setup Supabase CLI
+        if: ${{ steps.release.outputs.release_created }}
+        uses: supabase/setup-cli@v1
+        with:
+          version: 2.95.4
+
+      - name: Apply migrations to production
+        if: ${{ steps.release.outputs.release_created }}
+        run: supabase db push --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
       - name: Deploy production on release
         if: ${{ steps.release.outputs.release_created }}
         run: npx vercel deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Summary
- Agrega `supabase db push` al pipeline de release ANTES del deploy a Vercel
- Si las migraciones fallan, el deploy no se ejecuta — evita deployar código que requiere schema que no existe

## Motivation
Bug en prod: `createInvitationLink` fallaba con 500 porque la migración `add_link_invitations` nunca se aplicó en producción. El PR fue mergeado, se generó un release, Vercel deployó el nuevo código — pero Supabase seguía con el schema viejo.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/release-please.yml` | Setup Supabase CLI + `supabase db push` antes del `vercel deploy --prod` |

## Secrets requeridos (ya cargados)
- `SUPABASE_ACCESS_TOKEN` ✓
- `SUPABASE_PROJECT_REF` ✓

## Test plan
- [x] Secrets verificados en el repo
- [x] Orden correcto: migrate → deploy (si migrate falla, deploy no corre)