### PR TITLE
fix(dashboard): look up balance by userId instead of array index

### DIFF
--- a/src/app/(app)/dashboard/_components/balance-card.tsx
+++ b/src/app/(app)/dashboard/_components/balance-card.tsx
@@ -22,7 +22,13 @@ export function BalanceCard({
   const myFirstName = myProfile?.full_name.split(" ")[0] ?? "Vos";
   const partnerFirstName =
     partnerProfile?.full_name.split(" ")[0] ?? "Tu pareja";
-  const myPct = Math.round((balance.balances[0]?.percentage ?? 0.5) * 100);
+  const myBalance = balance.balances.find(
+    (b) => b.userId === myProfile?.user_id,
+  );
+  const partnerBalance = balance.balances.find(
+    (b) => b.userId === partnerProfile?.user_id,
+  );
+  const myPct = Math.round((myBalance?.percentage ?? 0.5) * 100);
 
   return (
     <div
@@ -78,7 +84,7 @@ export function BalanceCard({
                 fontFamily: "var(--font-sans)",
               }}
             >
-              {balance.debtor === balance.balances[0]?.userId
+              {balance.debtor === myProfile?.user_id
                 ? `${myFirstName} le debe a ${partnerFirstName}`
                 : `${partnerFirstName} le debe a ${myFirstName}`}
             </div>
@@ -121,7 +127,7 @@ export function BalanceCard({
               person: "a" as const,
               name: myFirstName,
               pct: myPct,
-              amt: balance.balances[0]?.obligation ?? 0,
+              amt: myBalance?.obligation ?? 0,
               color: "var(--person-a)",
               bg: "var(--person-a-subtle)",
             },
@@ -130,7 +136,7 @@ export function BalanceCard({
               person: "b" as const,
               name: partnerFirstName,
               pct: 100 - myPct,
-              amt: balance.balances[1]?.obligation ?? 0,
+              amt: partnerBalance?.obligation ?? 0,
               color: "var(--person-b)",
               bg: "var(--person-b-subtle)",
             },

--- a/src/lib/queries/use-monthly-data.ts
+++ b/src/lib/queries/use-monthly-data.ts
@@ -22,7 +22,8 @@ export function monthlyDataQueryOptions(
           .from("incomes")
           .select("*")
           .eq("couple_id", coupleId)
-          .eq("month", month),
+          .eq("month", month)
+          .order("created_at", { ascending: true }),
 
         supabase
           .from("installment_purchases")


### PR DESCRIPTION
## Summary
- Los porcentajes en el balance card se mostraban invertidos (Deivy 35% / Annie 65% cuando debería ser 65% / 35%)
- Root cause: `balance.balances[0]` asumía que el primer elemento siempre es el usuario actual, pero la query de incomes no tiene ORDER BY — Postgres devuelve filas en orden no determinístico
- Fix: reemplaza los 4 accesos por índice con `.find(b => b.userId === ...)` usando `myProfile.user_id` y `partnerProfile.user_id`

## Changes
| File | Change |
|------|--------|
| `src/app/(app)/dashboard/_components/balance-card.tsx` | `myBalance` y `partnerBalance` por userId lookup en lugar de `[0]`/`[1]` |
| `src/lib/queries/use-monthly-data.ts` | `ORDER BY created_at ASC` en query de incomes para consistencia |

## Test plan
- [x] 137 unit tests passing
- [x] Verificado en producción: Deivy tiene $3.210.000 (64.6%), Annie $1.760.000 (35.4%)