### PR TITLE
fix(fijo): enforce amount_override > 0 via DB CHECK constraint

### DIFF
--- a/supabase/migrations/20260608000002_add_amount_override_check.sql
+++ b/supabase/migrations/20260608000002_add_amount_override_check.sql
@@ -1,0 +1,7 @@
+-- Enforce amount_override > 0 at the database level (REQ-Schema, fixed-expense-editable-amount).
+-- The Server Action already validates this, but a CHECK adds defense-in-depth and matches the
+-- codebase convention of expressing data-integrity invariants as constraints.
+-- NULL is always allowed (NULL = use template default).
+alter table fixed_expense_instances
+  add constraint fixed_instance_amount_override_positive
+    check (amount_override is null or amount_override > 0);


### PR DESCRIPTION
## Summary
- Adds a CHECK constraint to `fixed_expense_instances.amount_override` (`IS NULL OR > 0`), as defense-in-depth alongside the existing Server Action validation.
- Reconciles REQ-Schema of the `fixed-expense-editable-amount` change: the original migration only added the column without the constraint the spec required.

## Changes
| File | Change |
|------|--------|
| `supabase/migrations/20260608000002_add_amount_override_check.sql` | New migration adding `fixed_instance_amount_override_positive` CHECK constraint |

## Test plan
- [x] `npx supabase db reset` — migration applies cleanly, verified against 14 existing rows (0 violations)
- [x] Manually verified: rejects 0/negative `amount_override`, accepts positive values and NULL
- [x] `npm test` — 137/137 pass
- [x] `npm run test:a11y` — 11/11 pass