### PR TITLE
fix(ci): use supabase link before db push in release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,7 +38,9 @@ jobs:
 
       - name: Apply migrations to production
         if: ${{ steps.release.outputs.release_created }}
-        run: supabase db push --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+        run: |
+          supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+          supabase db push
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Supabase CLI 2.95.4 removed `--project-ref` from `db push` — it now belongs to `supabase link`, with `db push` defaulting to `--linked`.
- Every release-please run since PR #119 (1.14.1 onward) has been failing on "Apply migrations to production" with `unknown flag: --project-ref`, which causes GitHub Actions to skip the subsequent "Deploy production on release" step — production has been stuck on v1.14.0 since then.

## Fix
Replace the failing command with `supabase link --project-ref ... && supabase db push`.

## Test plan
- [x] Existing test suite passes (ran on push via pre-push hook)
- [ ] Next release-please run successfully applies migrations and deploys to production