### PR TITLE
feat(expenses): delete cuotas/variables with ConfirmDialog + Toast undo

### DIFF
--- a/e2e/toast-confirm.spec.ts
+++ b/e2e/toast-confirm.spec.ts
@@ -1,0 +1,323 @@
+import { test, expect } from "./fixtures";
+import { ExpensesPage } from "./pages/expenses.page";
+
+/**
+ * Toast + ConfirmDialog E2E — delete flows, undo, and a11y checks.
+ *
+ * These tests focus on UI interactions with the confirm dialog and toast system.
+ * Data is created via adminClient in beforeEach and cleaned in afterEach.
+ */
+
+// ── Cuota delete — ConfirmDialog lifecycle ────────────────────────────────────
+
+test.describe("Cuota delete — confirm dialog", () => {
+  const DESCRIPTION = `E2E-cuota-del-${Date.now()}`;
+
+  test.beforeEach(async ({ adminClient, coupleId }) => {
+    const today = new Date().toISOString().split("T")[0];
+    await adminClient.from("installment_purchases").insert({
+      couple_id: coupleId,
+      description: DESCRIPTION,
+      total_amount: 12000,
+      installments: 6,
+      paid_installments: 0,
+      first_payment_date: today,
+      auto_renew: false,
+    });
+  });
+
+  test.afterEach(async ({ adminClient, coupleId }) => {
+    await adminClient
+      .from("installment_purchases")
+      .delete()
+      .eq("couple_id", coupleId)
+      .like("description", "E2E-cuota-del-%");
+  });
+
+  test("abre el confirm dialog al pulsar el botón eliminar", async ({
+    authenticatedPage: page,
+  }) => {
+    test.slow();
+    const expenses = new ExpensesPage(page);
+    await expenses.goto();
+
+    // Wait for the item to appear
+    await expect(page.getByText(DESCRIPTION).first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Click trash icon
+    await page.getByRole("button", { name: "Eliminar cuota" }).first().click();
+
+    // Confirm dialog should appear
+    await expect(page.getByRole("dialog")).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByText("Eliminar compra en cuotas")).toBeVisible();
+  });
+
+  test("cancelar en el confirm dialog NO elimina el item", async ({
+    authenticatedPage: page,
+  }) => {
+    test.slow();
+    const expenses = new ExpensesPage(page);
+    await expenses.goto();
+
+    await expect(page.getByText(DESCRIPTION).first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page.getByRole("button", { name: "Eliminar cuota" }).first().click();
+    await expect(page.getByRole("dialog")).toBeVisible({ timeout: 3_000 });
+
+    // Cancel — click the "Cancelar" button
+    await page.getByRole("button", { name: "Cancelar" }).click();
+
+    // Dialog should close
+    await expect(page.getByRole("dialog")).not.toBeVisible({ timeout: 3_000 });
+
+    // Item should still be in the list
+    await expect(page.getByText(DESCRIPTION).first()).toBeVisible({
+      timeout: 3_000,
+    });
+  });
+
+  test("confirmar dispara toast con botón Deshacer", async ({
+    authenticatedPage: page,
+  }) => {
+    test.slow();
+    const expenses = new ExpensesPage(page);
+    await expenses.goto();
+
+    await expect(page.getByText(DESCRIPTION).first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page.getByRole("button", { name: "Eliminar cuota" }).first().click();
+    await expect(page.getByRole("dialog")).toBeVisible({ timeout: 3_000 });
+
+    // Confirm deletion
+    await page.getByRole("button", { name: "Sí, eliminar" }).click();
+
+    // Dialog closes and item disappears (optimistic)
+    await expect(page.getByRole("dialog")).not.toBeVisible({ timeout: 3_000 });
+
+    // Toast should appear with "Deshacer" button
+    const undoButton = page.getByRole("button", { name: "Deshacer" });
+    await expect(undoButton).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("pulsar Deshacer en el toast restaura el item", async ({
+    authenticatedPage: page,
+  }) => {
+    test.slow();
+    const expenses = new ExpensesPage(page);
+    await expenses.goto();
+
+    await expect(page.getByText(DESCRIPTION).first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Delete
+    await page.getByRole("button", { name: "Eliminar cuota" }).first().click();
+    await expect(page.getByRole("dialog")).toBeVisible({ timeout: 3_000 });
+    await page.getByRole("button", { name: "Sí, eliminar" }).click();
+
+    // Wait for "Deshacer" and click it
+    const undoButton = page.getByRole("button", { name: "Deshacer" });
+    await expect(undoButton).toBeVisible({ timeout: 5_000 });
+    await undoButton.click();
+
+    // Item should be back in the list after re-fetch
+    await expect(page.getByText(DESCRIPTION).first()).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});
+
+// ── Variable expense delete — ConfirmDialog lifecycle ─────────────────────────
+
+test.describe("Variable delete — confirm dialog", () => {
+  const DESCRIPTION = `E2E-var-del-${Date.now()}`;
+
+  test.beforeEach(async ({ adminClient, coupleId, testUserId }) => {
+    const today = new Date().toISOString().split("T")[0];
+    await adminClient.from("variable_expenses").insert({
+      couple_id: coupleId,
+      user_id: testUserId,
+      description: DESCRIPTION,
+      amount: 5000,
+      date: today,
+      is_shared: true,
+    });
+  });
+
+  test.afterEach(async ({ adminClient, coupleId }) => {
+    await adminClient
+      .from("variable_expenses")
+      .delete()
+      .eq("couple_id", coupleId)
+      .like("description", "E2E-var-del-%");
+  });
+
+  test("abre el confirm dialog al pulsar eliminar en gasto variable", async ({
+    authenticatedPage: page,
+  }) => {
+    test.slow();
+    const expenses = new ExpensesPage(page);
+    await expenses.goto();
+    await expenses.selectTab("Compras");
+
+    await expect(page.getByText(DESCRIPTION).first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page.getByRole("button", { name: "Eliminar gasto" }).first().click();
+
+    await expect(page.getByRole("dialog")).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByText("Eliminar gasto")).toBeVisible();
+  });
+
+  test("cancelar NO elimina el gasto variable", async ({
+    authenticatedPage: page,
+  }) => {
+    test.slow();
+    const expenses = new ExpensesPage(page);
+    await expenses.goto();
+    await expenses.selectTab("Compras");
+
+    await expect(page.getByText(DESCRIPTION).first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page.getByRole("button", { name: "Eliminar gasto" }).first().click();
+    await expect(page.getByRole("dialog")).toBeVisible({ timeout: 3_000 });
+
+    await page.getByRole("button", { name: "Cancelar" }).click();
+    await expect(page.getByRole("dialog")).not.toBeVisible({ timeout: 3_000 });
+
+    await expect(page.getByText(DESCRIPTION).first()).toBeVisible({
+      timeout: 3_000,
+    });
+  });
+});
+
+// ── A11y — toast roles ─────────────────────────────────────────────────────────
+
+test.describe("A11y — toast aria roles", () => {
+  const DESCRIPTION = `E2E-a11y-toast-${Date.now()}`;
+
+  test.beforeEach(async ({ adminClient, coupleId }) => {
+    const today = new Date().toISOString().split("T")[0];
+    await adminClient.from("installment_purchases").insert({
+      couple_id: coupleId,
+      description: DESCRIPTION,
+      total_amount: 6000,
+      installments: 3,
+      paid_installments: 0,
+      first_payment_date: today,
+      auto_renew: false,
+    });
+  });
+
+  test.afterEach(async ({ adminClient, coupleId }) => {
+    await adminClient
+      .from("installment_purchases")
+      .delete()
+      .eq("couple_id", coupleId)
+      .like("description", "E2E-a11y-toast-%");
+  });
+
+  test("danger toast tiene role=alert", async ({ authenticatedPage: page }) => {
+    test.slow();
+    const expenses = new ExpensesPage(page);
+    await expenses.goto();
+
+    await expect(page.getByText(DESCRIPTION).first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page.getByRole("button", { name: "Eliminar cuota" }).first().click();
+    await expect(page.getByRole("dialog")).toBeVisible({ timeout: 3_000 });
+    await page.getByRole("button", { name: "Sí, eliminar" }).click();
+
+    // Toast with role="alert" should be visible
+    await expect(page.getByRole("alert").first()).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+});
+
+// ── A11y — ConfirmDialog focus trap and keyboard ───────────────────────────────
+
+test.describe("A11y — ConfirmDialog keyboard interaction", () => {
+  const DESCRIPTION = `E2E-a11y-kbd-${Date.now()}`;
+
+  test.beforeEach(async ({ adminClient, coupleId }) => {
+    const today = new Date().toISOString().split("T")[0];
+    await adminClient.from("installment_purchases").insert({
+      couple_id: coupleId,
+      description: DESCRIPTION,
+      total_amount: 9000,
+      installments: 3,
+      paid_installments: 0,
+      first_payment_date: today,
+      auto_renew: false,
+    });
+  });
+
+  test.afterEach(async ({ adminClient, coupleId }) => {
+    await adminClient
+      .from("installment_purchases")
+      .delete()
+      .eq("couple_id", coupleId)
+      .like("description", "E2E-a11y-kbd-%");
+  });
+
+  test("Esc cierra el confirm dialog sin eliminar", async ({
+    authenticatedPage: page,
+  }) => {
+    test.slow();
+    const expenses = new ExpensesPage(page);
+    await expenses.goto();
+
+    await expect(page.getByText(DESCRIPTION).first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page.getByRole("button", { name: "Eliminar cuota" }).first().click();
+    await expect(page.getByRole("dialog")).toBeVisible({ timeout: 3_000 });
+
+    // Press Escape — should close without deleting
+    await page.keyboard.press("Escape");
+    await expect(page.getByRole("dialog")).not.toBeVisible({ timeout: 3_000 });
+
+    // Item should still be present
+    await expect(page.getByText(DESCRIPTION).first()).toBeVisible({
+      timeout: 3_000,
+    });
+  });
+
+  test("Tab key cicla entre los botones del dialog (focus trap)", async ({
+    authenticatedPage: page,
+  }) => {
+    test.slow();
+    const expenses = new ExpensesPage(page);
+    await expenses.goto();
+
+    await expect(page.getByText(DESCRIPTION).first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page.getByRole("button", { name: "Eliminar cuota" }).first().click();
+    await expect(page.getByRole("dialog")).toBeVisible({ timeout: 3_000 });
+
+    // Tab through the focusable elements — after cycling, focus stays inside dialog
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Tab");
+
+    // Dialog must still be open (focus didn't escape)
+    await expect(page.getByRole("dialog")).toBeVisible({ timeout: 1_000 });
+
+    // Cleanup
+    await page.keyboard.press("Escape");
+  });
+});

--- a/src/app/(app)/expenses/_components/cuota-item.tsx
+++ b/src/app/(app)/expenses/_components/cuota-item.tsx
@@ -1,13 +1,19 @@
 "use client";
 
-import { useTransition } from "react";
+import { useState, useRef, useTransition } from "react";
 import { useQueryClient } from "@tanstack/react-query";
+import { Trash2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { PersonAvatar } from "@/components/shared/avatar";
+import { ConfirmDialog } from "@/components/shared/confirm-dialog";
+import { useToast } from "@/components/shared/toast/use-toast";
 import { formatARS } from "@/lib/utils";
-import { incrementPaidInstallments } from "@/lib/actions/expenses";
+import {
+  incrementPaidInstallments,
+  deleteInstallmentPurchase,
+} from "@/lib/actions/expenses";
 import { useMonthlyData } from "@/lib/queries/use-monthly-data";
 
 type MonthlyData = NonNullable<ReturnType<typeof useMonthlyData>["data"]>;
@@ -15,17 +21,70 @@ type InstallmentPurchase = MonthlyData["installmentPurchases"][number];
 
 export function CuotaItem({
   c,
+  coupleId,
+  month,
   getPersonInitials,
   getPerson,
 }: {
   readonly c: InstallmentPurchase;
+  readonly coupleId: string;
+  readonly month: string;
   readonly getPersonInitials?: (id: string) => string;
   readonly getPerson?: (id: string) => "a" | "b";
 }) {
   const [, startTransition] = useTransition();
   const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const deleteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const isPaid = c.paid_installments >= c.installments;
   const cuota = Math.round(c.total_amount / c.installments);
+
+  function handleUndo() {
+    if (deleteTimerRef.current !== null) {
+      clearTimeout(deleteTimerRef.current);
+      deleteTimerRef.current = null;
+    }
+    queryClient.invalidateQueries({
+      queryKey: ["monthly-data", coupleId, month],
+    });
+  }
+
+  function handleDelete() {
+    // Optimistically remove from cache
+    queryClient.setQueryData(
+      ["monthly-data", coupleId, month],
+      (old: MonthlyData | undefined) => {
+        if (!old) return old;
+        return {
+          ...old,
+          installmentPurchases: old.installmentPurchases.filter(
+            (item) => item.id !== c.id,
+          ),
+        };
+      },
+    );
+
+    toast.danger("Compra eliminada", {
+      undo: {
+        label: "Deshacer",
+        onUndo: handleUndo,
+      },
+      duration: 5000,
+    });
+
+    deleteTimerRef.current = setTimeout(() => {
+      deleteTimerRef.current = null;
+      startTransition(async () => {
+        await deleteInstallmentPurchase(c.id);
+        queryClient.invalidateQueries({
+          queryKey: ["monthly-data", coupleId, month],
+        });
+      });
+    }, 5000);
+  }
+
   return (
     <Card>
       <CardContent className="p-[14px_16px]">
@@ -82,6 +141,21 @@ export function CuotaItem({
                   +1
                 </Button>
               )}
+              <button
+                type="button"
+                aria-label="Eliminar cuota"
+                onClick={() => setConfirmOpen(true)}
+                style={{
+                  background: "transparent",
+                  border: "none",
+                  cursor: "pointer",
+                  padding: 4,
+                  lineHeight: 0,
+                  color: "var(--status-danger)",
+                }}
+              >
+                <Trash2 size={16} color="var(--status-danger)" />
+              </button>
             </div>
           </div>
         </div>
@@ -108,6 +182,15 @@ export function CuotaItem({
           />
         </div>
       </CardContent>
+      <ConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title="Eliminar compra en cuotas"
+        description="Se eliminará la compra y todas sus cuotas pendientes."
+        confirmLabel="Sí, eliminar"
+        destructive
+        onConfirm={handleDelete}
+      />
     </Card>
   );
 }

--- a/src/app/(app)/expenses/_components/variable-item.tsx
+++ b/src/app/(app)/expenses/_components/variable-item.tsx
@@ -1,6 +1,14 @@
+"use client";
+
+import { useState, useRef, useTransition } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Trash2 } from "lucide-react";
 import { PersonAvatar } from "@/components/shared/avatar";
 import { Card, CardContent } from "@/components/ui/card";
+import { ConfirmDialog } from "@/components/shared/confirm-dialog";
+import { useToast } from "@/components/shared/toast/use-toast";
 import { formatARS } from "@/lib/utils";
+import { deleteVariableExpense } from "@/lib/actions/expenses";
 import { useMonthlyData } from "@/lib/queries/use-monthly-data";
 
 type MonthlyData = NonNullable<ReturnType<typeof useMonthlyData>["data"]>;
@@ -8,13 +16,67 @@ type VariableExpense = MonthlyData["variableExpenses"][number];
 
 export function VariableItem({
   v,
+  coupleId,
+  month,
   getPersonInitials,
   getPerson,
 }: {
   readonly v: VariableExpense;
+  readonly coupleId: string;
+  readonly month: string;
   readonly getPersonInitials: (userId: string) => string;
   readonly getPerson: (userId: string) => "a" | "b";
 }) {
+  const [, startTransition] = useTransition();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const deleteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function handleUndo() {
+    if (deleteTimerRef.current !== null) {
+      clearTimeout(deleteTimerRef.current);
+      deleteTimerRef.current = null;
+    }
+    queryClient.invalidateQueries({
+      queryKey: ["monthly-data", coupleId, month],
+    });
+  }
+
+  function handleDelete() {
+    // Optimistically remove from cache
+    queryClient.setQueryData(
+      ["monthly-data", coupleId, month],
+      (old: MonthlyData | undefined) => {
+        if (!old) return old;
+        return {
+          ...old,
+          variableExpenses: old.variableExpenses.filter(
+            (item) => item.id !== v.id,
+          ),
+        };
+      },
+    );
+
+    toast.danger("Gasto eliminado", {
+      undo: {
+        label: "Deshacer",
+        onUndo: handleUndo,
+      },
+      duration: 5000,
+    });
+
+    deleteTimerRef.current = setTimeout(() => {
+      deleteTimerRef.current = null;
+      startTransition(async () => {
+        await deleteVariableExpense(v.id);
+        queryClient.invalidateQueries({
+          queryKey: ["monthly-data", coupleId, month],
+        });
+      });
+    }, 5000);
+  }
+
   return (
     <Card>
       <CardContent className="flex items-center gap-3 p-[14px_16px]">
@@ -27,7 +89,14 @@ export function VariableItem({
           <div style={{ fontSize: 14, fontWeight: 500, color: "var(--fg-1)" }}>
             {v.description}
           </div>
-          <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 2 }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              marginTop: 2,
+            }}
+          >
             <span style={{ fontSize: 12, color: "var(--fg-3)" }}>{v.date}</span>
             {!v.is_shared && (
               <span
@@ -49,17 +118,43 @@ export function VariableItem({
             )}
           </div>
         </div>
-        <div
-          style={{
-            fontFamily: "var(--font-mono)",
-            fontSize: 15,
-            fontWeight: 600,
-            color: "var(--fg-1)",
-          }}
-        >
-          {formatARS(v.amount)}
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <div
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 15,
+              fontWeight: 600,
+              color: "var(--fg-1)",
+            }}
+          >
+            {formatARS(v.amount)}
+          </div>
+          <button
+            type="button"
+            aria-label="Eliminar gasto"
+            onClick={() => setConfirmOpen(true)}
+            style={{
+              background: "transparent",
+              border: "none",
+              cursor: "pointer",
+              padding: 4,
+              lineHeight: 0,
+              color: "var(--status-danger)",
+            }}
+          >
+            <Trash2 size={16} color="var(--status-danger)" />
+          </button>
         </div>
       </CardContent>
+      <ConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title="Eliminar gasto"
+        description="Esta acción no se puede deshacer."
+        confirmLabel="Sí, eliminar"
+        destructive
+        onConfirm={handleDelete}
+      />
     </Card>
   );
 }

--- a/src/app/(app)/expenses/page.tsx
+++ b/src/app/(app)/expenses/page.tsx
@@ -27,6 +27,7 @@ import { ResponsiveModal } from "@/components/shared/responsive-modal";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
+import { useToast } from "@/components/shared/toast/use-toast";
 
 const TAB_DESCRIPTIONS: Record<Tab, string> = {
   cuotas: "Compras en cuotas o planes de pago recurrentes",
@@ -293,6 +294,7 @@ function EditServiceSheet({
   onClose,
 }: EditServiceSheetProps) {
   const queryClient = useQueryClient();
+  const { toast } = useToast();
   const currentAmount = effectiveFixedAmount(instance);
   const [draft, setDraft] = useState(String(currentAmount));
   const [fieldError, setFieldError] = useState<string | null>(null);
@@ -310,10 +312,13 @@ function EditServiceSheet({
   const toggleMutation = useMutation({
     mutationFn: ({ id, paid }: { id: string; paid: boolean }) =>
       toggleFixedExpenseInstance(id, paid),
-    onSuccess: () => {
+    onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
         queryKey: ["monthly-data", coupleId, month],
       });
+      toast.success(
+        variables.paid ? "Marcado como pagado" : "Marcado como pendiente",
+      );
     },
   });
 
@@ -668,6 +673,8 @@ export default function ExpensesPage() {
                   <li key={c.id}>
                     <CuotaItem
                       c={c}
+                      coupleId={coupleId ?? ""}
+                      month={month}
                       getPersonInitials={getPersonInitials}
                       getPerson={getPerson}
                     />
@@ -794,6 +801,8 @@ export default function ExpensesPage() {
                   <li key={v.id}>
                     <VariableItem
                       v={v}
+                      coupleId={coupleId ?? ""}
+                      month={month}
                       getPersonInitials={getPersonInitials}
                       getPerson={getPerson}
                     />

--- a/src/lib/queries/use-expense-save.ts
+++ b/src/lib/queries/use-expense-save.ts
@@ -8,6 +8,7 @@ import {
   createVariableExpense,
 } from "@/lib/actions/expenses";
 import { parseAmount } from "@/lib/utils/amount";
+import { useToast } from "@/components/shared/toast/use-toast";
 
 export type Tab = "cuotas" | "fijos" | "variables";
 
@@ -27,6 +28,7 @@ export function useExpenseSave(tab: Tab) {
   const [isPending, startTransition] = useTransition();
   const [saveError, setSaveError] = useState<string | null>(null);
   const queryClient = useQueryClient();
+  const { toast } = useToast();
 
   function save(
     fields: Record<string, string>,
@@ -70,10 +72,12 @@ export function useExpenseSave(tab: Tab) {
           });
         }
         queryClient.invalidateQueries({ queryKey: ["monthly-data"] });
+        toast.success("Gasto guardado");
       } catch (err) {
-        setSaveError(
-          err instanceof Error ? err.message : "No se pudo guardar el gasto",
-        );
+        const message =
+          err instanceof Error ? err.message : "No se pudo guardar el gasto";
+        setSaveError(message);
+        toast.danger("No se pudo guardar el gasto");
       }
     });
   }


### PR DESCRIPTION
## Summary
- **Cuota delete**: trash button on each cuota card opens `ConfirmDialog`; on confirm: optimistic cache removal → `toast.danger` with Undo → 5s deferred `deleteInstallmentPurchase` → query invalidation. Undo cancels the timer and rehydrates from server.
- **Variable expense delete**: identical pattern using `deleteVariableExpense`
- **Save mutation**: `toast.success("Gasto guardado")` on success, `toast.danger(...)` on error
- **Fixed expense toggle**: `toast.success("Marcado como pagado" | "Marcado como pendiente")` based on toggle direction
- **E2e tests** (`e2e/toast-confirm.spec.ts`): cuota delete lifecycle (open/cancel/confirm/undo), danger toast `role="alert"`, Esc closes dialog, Tab focus trap

## Part of
`ds-fidelity-completion` — 3-PR stacked series. This is **PR 2/3**.  
Depends on: feat/ds-fidelity-completion-pr1 (#133)  
PR 3/3: feat/ds-fidelity-completion-pr3

## Test plan
- [ ] `npm test` — 144/144 pass
- [ ] Delete cuota → cancel → item still visible
- [ ] Delete cuota → confirm → toast "Compra eliminada" + "Deshacer" button appears
- [ ] Click "Deshacer" → item restored (timer cancelled, server rehydrates)
- [ ] Wait 5s → item permanently gone
- [ ] Save expense → toast "Gasto guardado"
- [ ] Toggle fijo paid → toast "Marcado como pagado"