### PR TITLE
fix(tokens): dark-mode sweep, BottomNav frosted glass, History % labels

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -57,7 +57,7 @@ function MonthlyFixedSummary({
           <span
             style={{
               fontSize: 12,
-              color: "var(--color-teal)",
+              color: "var(--status-success-text)",
               fontWeight: 600,
             }}
           >
@@ -67,7 +67,7 @@ function MonthlyFixedSummary({
             <span
               style={{
                 fontSize: 12,
-                color: "var(--color-coral)",
+                color: "var(--status-danger-text)",
                 fontWeight: 600,
               }}
             >
@@ -170,9 +170,7 @@ export default function DashboardPage() {
   }
 
   return (
-    <div
-      style={{ minHeight: "100%", background: "var(--bg-base)" }}
-    >
+    <div style={{ minHeight: "100%", background: "var(--bg-base)" }}>
       <h1 className="sr-only">Inicio</h1>
       <MonthHeader
         month={formatMonth(month)}
@@ -244,12 +242,12 @@ export default function DashboardPage() {
                   background: "var(--accent)",
                   borderRadius: 14,
                   padding: "15px 20px",
-                  color: "white",
+                  color: "var(--accent-foreground)",
                   fontSize: 15,
                   fontWeight: 600,
                   fontFamily: "var(--font-sans)",
                   textDecoration: "none",
-                  boxShadow: "0 4px 16px rgba(108,92,231,0.35)",
+                  boxShadow: "var(--shadow-accent)",
                   marginBottom: 8,
                 }}
               >

--- a/src/app/(app)/history/_components/month-detail.tsx
+++ b/src/app/(app)/history/_components/month-detail.tsx
@@ -10,11 +10,13 @@ export function MonthDetail({
   data,
   isLoading = false,
   onBack,
+  getPersonName,
 }: {
   readonly month: string;
   readonly data: MonthlyData | undefined;
   readonly isLoading?: boolean;
   readonly onBack: () => void;
+  readonly getPersonName?: (userId: string) => string;
 }) {
   const balance = data
     ? calculateMonthlyBalance({
@@ -164,7 +166,7 @@ export function MonthDetail({
               <div
                 style={{
                   marginTop: 14,
-                  background: "var(--color-neutral-200)",
+                  background: "var(--border-default)",
                   borderRadius: 99,
                   height: 6,
                   display: "flex",
@@ -180,6 +182,33 @@ export function MonthDetail({
                         i === 0 ? "var(--person-a)" : "var(--person-b)",
                     }}
                   />
+                ))}
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  marginTop: 6,
+                }}
+              >
+                {balance.balances.map((b, i) => (
+                  <span
+                    key={b.userId}
+                    style={{
+                      fontSize: "var(--text-sm)",
+                      fontWeight: "var(--weight-medium)",
+                      fontFamily: "var(--font-sans)",
+                      color:
+                        i === 0
+                          ? "var(--person-a-text)"
+                          : "var(--person-b-text)",
+                    }}
+                  >
+                    {getPersonName
+                      ? getPersonName(b.userId)
+                      : b.userId.slice(0, 6) + "…"}{" "}
+                    {Math.round(b.percentage * 100)}%
+                  </span>
                 ))}
               </div>
             </div>

--- a/src/app/(app)/history/page.tsx
+++ b/src/app/(app)/history/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useQueries } from "@tanstack/react-query";
 import {
   useCoupleMember,
+  useCoupleMemberProfiles,
   monthlyDataQueryOptions,
 } from "@/lib/queries/use-monthly-data";
 import { getHistoryMonths } from "@/lib/queries/history";
@@ -14,6 +15,12 @@ export default function HistoryPage() {
   const [selected, setSelected] = useState<string | null>(null);
   const { data: member } = useCoupleMember();
   const coupleId = member?.couple_id ?? null;
+  const { data: profiles = [] } = useCoupleMemberProfiles(
+    member?.user_id ?? null,
+  );
+  const getPersonName = (userId: string) =>
+    profiles.find((p) => p.user_id === userId)?.full_name ??
+    userId.slice(0, 6) + "…";
   const months = getHistoryMonths();
 
   const queries = useQueries({
@@ -32,6 +39,7 @@ export default function HistoryPage() {
         data={queries[idx]?.data ?? undefined}
         isLoading={queries[idx]?.isLoading ?? false}
         onBack={() => setSelected(null)}
+        getPersonName={getPersonName}
       />
     );
   }

--- a/src/components/navigation/bottom-nav.tsx
+++ b/src/components/navigation/bottom-nav.tsx
@@ -20,7 +20,9 @@ export function BottomNav() {
       aria-label="Navegación principal"
       className="fixed right-0 bottom-0 left-0 z-50 lg:hidden"
       style={{
-        background: "var(--bg-elevated)",
+        background: "color-mix(in srgb, var(--bg-elevated) 92%, transparent)",
+        backdropFilter: "blur(20px)",
+        WebkitBackdropFilter: "blur(20px)",
         borderTop: "1px solid var(--border-subtle)",
         paddingBottom: "env(safe-area-inset-bottom)",
       }}
@@ -49,6 +51,17 @@ export function BottomNav() {
                 className={cn("size-5 shrink-0", isActive && "stroke-[2.2]")}
               />
               {item.label}
+              <span
+                style={{
+                  width: 4,
+                  height: 4,
+                  borderRadius: "50%",
+                  background: "var(--accent)",
+                  margin: "2px auto 0",
+                  visibility: isActive ? "visible" : "hidden",
+                }}
+                aria-hidden="true"
+              />
             </Link>
           );
         })}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -25,8 +25,7 @@ const badgeVariants = cva(
           "[background-color:var(--status-danger-subtle)] [color:var(--status-danger)]",
         warning:
           "[background-color:var(--status-warning-subtle)] [color:var(--status-warning-fg)]",
-        neutral:
-          "[background-color:var(--color-neutral-100)] [color:var(--fg-2)]",
+        neutral: "[background-color:var(--bg-sunken)] [color:var(--fg-2)]",
         accent: "[background-color:var(--accent-subtle)] [color:var(--accent)]",
       },
     },


### PR DESCRIPTION
## Summary
- **Dashboard CTA**: hardcoded `color: white` + `rgba(108,92,231,0.35)` → `var(--accent-foreground)` + `var(--shadow-accent)` (fixes broken dark-mode CTA)
- **MonthlyFixedSummary**: undefined `--color-teal`/`--color-coral` → `--status-success-text`/`--status-danger-text`
- **Badge `neutral` variant**: `--color-neutral-100` (light-only) → `--bg-sunken` (dark-mode safe)
- **MonthDetail bar track**: `--color-neutral-200` (light-only) → `--border-default`
- **MonthDetail person % labels**: adds "Deivy 65% · Annie 35%" row below the proportion bar using real display names via `useCoupleMemberProfiles` threaded from `history/page.tsx`; colors via `--person-a-text`/`--person-b-text`
- **BottomNav**: frosted glass background (`color-mix` + `backdrop-filter: blur(20px)`) + active-dot indicator (4×4px circle in `--accent` below active tab label)

## Part of
`ds-fidelity-completion` — 3-PR stacked series. This is **PR 3/3**.  
Depends on: feat/ds-fidelity-completion-pr1 (#133) → feat/ds-fidelity-completion-pr2 (#134)

## Test plan
- [ ] `npm test` — 144/144 pass
- [ ] Dark mode: toggle `.dark` class — CTA button, fixed-summary amounts, badge neutral all render correctly
- [ ] History detail: person % labels show first names, not UUID fragments
- [ ] BottomNav: frosted glass visible over content; active tab shows dot indicator