### PR TITLE
feat: design-system fidelity, dark-mode a11y, and UX bug-fix pass

### DIFF
--- a/src/app/(app)/dashboard/_components/balance-card.tsx
+++ b/src/app/(app)/dashboard/_components/balance-card.tsx
@@ -69,7 +69,7 @@ export function BalanceCard({
                 fontFamily: "var(--font-mono)",
                 fontSize: 38,
                 fontWeight: 700,
-                color: "var(--status-danger)",
+                color: "var(--status-danger-text)",
                 letterSpacing: "-0.02em",
                 lineHeight: 1.1,
               }}
@@ -97,7 +97,7 @@ export function BalanceCard({
                 fontFamily: "var(--font-mono)",
                 fontSize: 38,
                 fontWeight: 700,
-                color: "var(--status-success)",
+                color: "var(--status-success-text)",
                 letterSpacing: "-0.02em",
                 lineHeight: 1.1,
               }}

--- a/src/app/(app)/dashboard/_components/new-instances-banner.tsx
+++ b/src/app/(app)/dashboard/_components/new-instances-banner.tsx
@@ -14,7 +14,7 @@ export function NewInstancesBanner({
   return (
     <Alert className="mb-3 flex items-center justify-between gap-2 border-(--status-success-subtle) bg-(--status-success-subtle) py-2.5">
       <AlertDescription
-        style={{ color: "var(--status-success)" }}
+        style={{ color: "var(--status-success-text)" }}
         className="text-[13px] font-medium"
       >
         ✓ {count} gasto{plural ? "s" : ""} fijo{plural ? "s" : ""} generado
@@ -24,7 +24,7 @@ export function NewInstancesBanner({
         variant="ghost"
         size="icon"
         className="size-6 shrink-0"
-        style={{ color: "var(--status-success)" }}
+        style={{ color: "var(--status-success-text)" }}
         onClick={onDismiss}
         aria-label="Cerrar"
       >

--- a/src/app/(app)/dashboard/_components/pending-review-banner.tsx
+++ b/src/app/(app)/dashboard/_components/pending-review-banner.tsx
@@ -5,16 +5,21 @@ export function PendingReviewBanner({ count }: { readonly count: number }) {
   if (count === 0) return null;
   const plural = count > 1;
   return (
-    <Link href="/expenses" data-testid="pending-review-link" style={{ textDecoration: "none" }}>
+    <Link
+      href="/expenses"
+      data-testid="pending-review-link"
+      style={{ textDecoration: "none" }}
+    >
       <Alert
-        className="mb-3 flex items-center gap-2 border-(--color-coral) py-2.5"
+        className="mb-3 flex items-center gap-2 border-(--status-danger-text) py-2.5"
         style={{
-          background: "color-mix(in srgb, var(--color-coral) 10%, transparent)",
+          background:
+            "color-mix(in srgb, var(--status-danger) 10%, transparent)",
           cursor: "pointer",
         }}
       >
         <AlertDescription
-          style={{ color: "var(--color-coral)" }}
+          style={{ color: "var(--status-danger-text)" }}
           className="text-[13px] font-medium"
         >
           {count} servicio{plural ? "s" : ""} necesita{plural ? "n" : ""}{" "}

--- a/src/app/(app)/dashboard/_components/upcoming-dues-widget.tsx
+++ b/src/app/(app)/dashboard/_components/upcoming-dues-widget.tsx
@@ -182,7 +182,11 @@ export function UpcomingDuesWidget({
         </h3>
 
         <DueSection
-          title={<><span aria-hidden="true">🔴</span> Vence hoy</>}
+          title={
+            <>
+              <span aria-hidden="true">🔴</span> Vence hoy
+            </>
+          }
           titleColor="var(--accent)"
           items={todayDues}
           showPayButton
@@ -190,15 +194,23 @@ export function UpcomingDuesWidget({
           payingId={payingId}
         />
         <DueSection
-          title={<><span aria-hidden="true">⚠️</span> Vencidos</>}
-          titleColor="var(--color-coral)"
+          title={
+            <>
+              <span aria-hidden="true">⚠️</span> Vencidos
+            </>
+          }
+          titleColor="var(--status-danger-text)"
           items={overdue}
           showPayButton
           onPay={pay}
           payingId={payingId}
         />
         <DueSection
-          title={<><span aria-hidden="true">📅</span> Esta semana</>}
+          title={
+            <>
+              <span aria-hidden="true">📅</span> Esta semana
+            </>
+          }
           titleColor="var(--fg-2)"
           items={upcoming}
           showPayButton={false}

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,7 +1,8 @@
 ﻿"use client";
 
-import { useState, useEffect, useMemo } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useState, useEffect, useMemo, Suspense } from "react";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { addMonths, subMonths } from "date-fns";
 import { Card, CardContent } from "@/components/ui/card";
 import { MonthHeader } from "@/components/shared/month-header";
@@ -21,7 +22,10 @@ import {
 } from "@/lib/utils/balance";
 import { groupByCategory } from "@/lib/utils/categories";
 import { MonthSummaryCard } from "@/components/shared/month-summary-card";
-import { ensureFixedExpenseInstances } from "@/lib/actions/expenses";
+import {
+  ensureFixedExpenseInstances,
+  ensureIncomeCarriedForward,
+} from "@/lib/actions/expenses";
 import { NoCoupleState } from "./_components/no-couple-state";
 import { NewInstancesBanner } from "./_components/new-instances-banner";
 import { PendingReviewBanner } from "./_components/pending-review-banner";
@@ -57,7 +61,7 @@ function MonthlyFixedSummary({
           <span
             style={{
               fontSize: 12,
-              color: "var(--color-teal)",
+              color: "var(--status-success-text)",
               fontWeight: 600,
             }}
           >
@@ -67,7 +71,7 @@ function MonthlyFixedSummary({
             <span
               style={{
                 fontSize: 12,
-                color: "var(--color-coral)",
+                color: "var(--status-danger-text)",
                 fontWeight: 600,
               }}
             >
@@ -82,11 +86,46 @@ function MonthlyFixedSummary({
 
 // ── PAGE ──────────────────────────────────────────────────────────────────────
 
-export default function DashboardPage() {
-  const [currentDate, setCurrentDate] = useState(new Date());
+/** Parses a "YYYY-MM" URL param into the first day of that month (local). */
+function monthParamToDate(param: string | null): Date {
+  if (param && /^\d{4}-\d{2}$/.test(param)) {
+    const [y, m] = param.split("-").map(Number);
+    if (m >= 1 && m <= 12) return new Date(y, m - 1, 1);
+  }
+  return new Date();
+}
+
+function DashboardView() {
+  const queryClient = useQueryClient();
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const [currentDate, setCurrentDate] = useState(() =>
+    monthParamToDate(searchParams.get("mes")),
+  );
   const [newInstancesBanner, setNewInstancesBanner] = useState(0);
   const month = getMonthDate(currentDate);
   const isCurrentMonth = month === getMonthDate();
+
+  // Sync the selected month to the URL (?mes=YYYY-MM). Current month = clean URL.
+  useEffect(() => {
+    const params = new URLSearchParams(Array.from(searchParams.entries()));
+    if (isCurrentMonth) {
+      params.delete("mes");
+    } else {
+      params.set(
+        "mes",
+        `${currentDate.getFullYear()}-${String(currentDate.getMonth() + 1).padStart(2, "0")}`,
+      );
+    }
+    const next = params.toString();
+    if (next !== searchParams.toString()) {
+      router.replace(next ? `${pathname}?${next}` : pathname, {
+        scroll: false,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- URL sync keys on the selected month; router/searchParams/pathname are stable and excluded to avoid loops
+  }, [currentDate, isCurrentMonth]);
 
   const { data: member, isLoading: loadingMember } = useCoupleMember();
   const { data: myPendingInvitations = [] } = useMyPendingInvitations();
@@ -105,9 +144,26 @@ export default function DashboardPage() {
     },
   });
 
+  const { mutate: ensureIncomeCarry } = useMutation({
+    mutationFn: (vars: { coupleId: string; month: string }) =>
+      ensureIncomeCarriedForward(vars.coupleId, vars.month),
+    onSuccess: ({ created }) => {
+      if (created > 0) {
+        queryClient.invalidateQueries({ queryKey: ["monthly-data"] });
+        queryClient.invalidateQueries({ queryKey: ["income-with-carry"] });
+      }
+    },
+  });
+
   useEffect(() => {
     if (coupleId) ensureInstances({ coupleId, month });
     // ensureInstances is stable (useMutation)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [coupleId, month]);
+
+  useEffect(() => {
+    if (coupleId) ensureIncomeCarry({ coupleId, month });
+    // ensureIncomeCarry is stable (useMutation)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [coupleId, month]);
 
@@ -170,9 +226,7 @@ export default function DashboardPage() {
   }
 
   return (
-    <div
-      style={{ minHeight: "100%", background: "var(--bg-base)" }}
-    >
+    <div style={{ minHeight: "100%", background: "var(--bg-base)" }}>
       <h1 className="sr-only">Inicio</h1>
       <MonthHeader
         month={formatMonth(month)}
@@ -261,5 +315,13 @@ export default function DashboardPage() {
         </div>
       )}
     </div>
+  );
+}
+
+export default function DashboardPage() {
+  return (
+    <Suspense fallback={null}>
+      <DashboardView />
+    </Suspense>
   );
 }

--- a/src/app/(app)/expenses/_components/add-sheet.tsx
+++ b/src/app/(app)/expenses/_components/add-sheet.tsx
@@ -89,6 +89,12 @@ const schemas: Record<Tab, z.ZodTypeAny> = {
   variables: variablesSchema,
 };
 
+const SAVE_LABEL: Record<Tab, string> = {
+  fijos: "Guardar servicio",
+  cuotas: "Guardar cuota",
+  variables: "Guardar compra",
+};
+
 // ── SUB-COMPONENTS ────────────────────────────────────────────────────────────
 
 // Monetary input: DS pattern — wrapper div + $ prefix + borderless inner input
@@ -587,11 +593,7 @@ export function AddSheet({
         )}
 
         <Button type="submit" style={{ width: "100%" }}>
-          {tab === "fijos"
-            ? "Guardar servicio"
-            : tab === "cuotas"
-              ? "Guardar cuota"
-              : "Guardar compra"}
+          {SAVE_LABEL[tab]}
         </Button>
       </form>
     </ResponsiveModal>

--- a/src/app/(app)/expenses/_components/add-sheet.tsx
+++ b/src/app/(app)/expenses/_components/add-sheet.tsx
@@ -14,6 +14,7 @@ import { PersonAvatar } from "@/components/shared/avatar";
 import { useCategories } from "@/lib/queries/use-monthly-data";
 import type { Tab } from "@/lib/queries/use-expense-save";
 import { TAB_LABEL } from "./segmented-control";
+import { DueDayPicker } from "./due-day-picker";
 import { computeMonthlyInstallment } from "@/lib/utils/installments";
 import { cn, formatARS, getInitials } from "@/lib/utils";
 import { parseAmount } from "@/lib/utils/amount";
@@ -77,7 +78,7 @@ const labelCss: React.CSSProperties = {
 
 const errorCss: React.CSSProperties = {
   fontSize: 12,
-  color: "var(--status-danger)",
+  color: "var(--status-danger-text)",
   marginTop: 4,
   fontFamily: "var(--font-sans)",
 };
@@ -108,6 +109,7 @@ function MoneyField({
         {label}
       </label>
       <div
+        className="focus-within:ring-2 focus-within:ring-(--accent)"
         style={{
           display: "flex",
           alignItems: "center",
@@ -237,9 +239,17 @@ export function AddSheet({
   const {
     register,
     control,
+    setValue,
     handleSubmit,
     formState: { errors },
   } = useForm<Fields>({ resolver: zodResolver(schemas[tab]) });
+
+  // Selected due day (fijos tab) — drives the grid picker highlight
+  const dueDayRaw = useWatch({ control, name: "due_day" });
+  const dueDayValue = useMemo(() => {
+    const n = Number.parseInt(dueDayRaw ?? "", 10);
+    return Number.isFinite(n) && n >= 1 && n <= 31 ? n : null;
+  }, [dueDayRaw]);
 
   // Live monthly installment calculation (cuotas tab only)
   const totalAmountRaw = useWatch({ control, name: "total_amount" });
@@ -337,13 +347,35 @@ export function AddSheet({
         )}
 
         {tab === "fijos" && (
-          <InputField
-            label="Día de vencimiento (1-31)"
-            id="field-due-day"
-            registration={register("due_day")}
-            error={errors.due_day?.message}
-            mono
-          />
+          <div style={{ marginBottom: 14 }}>
+            <label htmlFor="field-due-day" style={labelCss}>
+              Día de vencimiento (1-31)
+            </label>
+            {/* Visually-hidden native input keeps the field addressable/fillable
+                for a11y + e2e while the grid is the visual control. */}
+            <input
+              id="field-due-day"
+              data-testid="field-due-day"
+              type="text"
+              inputMode="numeric"
+              className="sr-only"
+              {...register("due_day")}
+            />
+            <DueDayPicker
+              value={dueDayValue}
+              onChange={(day) =>
+                setValue("due_day", String(day), {
+                  shouldValidate: true,
+                  shouldDirty: true,
+                })
+              }
+            />
+            {errors.due_day?.message && (
+              <div role="alert" style={errorCss}>
+                {errors.due_day.message}
+              </div>
+            )}
+          </div>
         )}
 
         {tab === "fijos" && (
@@ -547,7 +579,7 @@ export function AddSheet({
               background:
                 "color-mix(in srgb, var(--status-danger) 10%, transparent)",
               borderRadius: 8,
-              border: "1px solid var(--status-danger)",
+              border: "1px solid var(--status-danger-text)",
             }}
           >
             {saveError}
@@ -555,7 +587,11 @@ export function AddSheet({
         )}
 
         <Button type="submit" style={{ width: "100%" }}>
-          Guardar
+          {tab === "fijos"
+            ? "Guardar servicio"
+            : tab === "cuotas"
+              ? "Guardar cuota"
+              : "Guardar compra"}
         </Button>
       </form>
     </ResponsiveModal>

--- a/src/app/(app)/expenses/_components/cuota-item.tsx
+++ b/src/app/(app)/expenses/_components/cuota-item.tsx
@@ -29,10 +29,17 @@ export function CuotaItem({
   return (
     <Card>
       <CardContent className="p-[14px_16px]">
-        <div className="mb-2 flex items-start justify-between">
-          <div>
+        <div className="mb-2 flex items-start justify-between gap-3">
+          <div className="min-w-0">
             <div
-              style={{ fontSize: 15, fontWeight: 500, color: "var(--fg-1)" }}
+              style={{
+                fontSize: 15,
+                fontWeight: 500,
+                color: "var(--fg-1)",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
             >
               {c.description}
             </div>
@@ -42,7 +49,7 @@ export function CuotaItem({
               {c.auto_renew ? <span aria-hidden="true"> 🔄</span> : ""}
             </div>
           </div>
-          <div className="flex flex-col items-end gap-1">
+          <div className="flex shrink-0 flex-col items-end gap-1">
             <div className="flex items-center gap-1.5">
               {c.paid_by_user_id && getPersonInitials && getPerson && (
                 <PersonAvatar

--- a/src/app/(app)/expenses/_components/due-day-picker.tsx
+++ b/src/app/(app)/expenses/_components/due-day-picker.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+const DAYS = Array.from({ length: 31 }, (_, i) => i + 1);
+
+export function DueDayPicker({
+  value,
+  onChange,
+}: {
+  readonly value: number | null;
+  readonly onChange: (day: number) => void;
+}) {
+  return (
+    <div>
+      <div
+        style={{
+          fontSize: 12,
+          color: "var(--fg-3)",
+          marginBottom: 8,
+          fontFamily: "var(--font-sans)",
+        }}
+      >
+        Se repite todos los meses el día{" "}
+        <strong
+          style={{
+            color: "var(--fg-1)",
+            fontFamily: "var(--font-mono)",
+            fontWeight: 700,
+          }}
+        >
+          {value ?? "—"}
+        </strong>
+      </div>
+      <div
+        role="group"
+        aria-label="Día de vencimiento"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(7, 1fr)",
+          gap: 4,
+        }}
+      >
+        {DAYS.map((day) => {
+          const selected = value === day;
+          return (
+            <button
+              key={day}
+              type="button"
+              aria-pressed={selected}
+              aria-label={`Día ${day}`}
+              onClick={() => onChange(day)}
+              style={{
+                aspectRatio: "1",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                borderRadius: 8,
+                fontFamily: "var(--font-mono)",
+                fontSize: 13,
+                fontWeight: selected ? 700 : 500,
+                background: selected ? "var(--accent)" : "var(--bg-elevated)",
+                color: selected ? "var(--accent-foreground)" : "var(--fg-2)",
+                border: selected
+                  ? "1.5px solid var(--accent)"
+                  : "1px solid var(--border-subtle)",
+                cursor: "pointer",
+                transition:
+                  "background-color 150ms, border-color 150ms, color 150ms",
+              }}
+            >
+              {day}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/expenses/_components/due-day-picker.tsx
+++ b/src/app/(app)/expenses/_components/due-day-picker.tsx
@@ -30,48 +30,49 @@ export function DueDayPicker({
           {value ?? "—"}
         </strong>
       </div>
-      <div
-        role="group"
-        aria-label="Día de vencimiento"
-        style={{
-          display: "grid",
-          gridTemplateColumns: "repeat(7, 1fr)",
-          gap: 4,
-        }}
-      >
-        {DAYS.map((day) => {
-          const selected = value === day;
-          return (
-            <button
-              key={day}
-              type="button"
-              aria-pressed={selected}
-              aria-label={`Día ${day}`}
-              onClick={() => onChange(day)}
-              style={{
-                aspectRatio: "1",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                borderRadius: 8,
-                fontFamily: "var(--font-mono)",
-                fontSize: 13,
-                fontWeight: selected ? 700 : 500,
-                background: selected ? "var(--accent)" : "var(--bg-elevated)",
-                color: selected ? "var(--accent-foreground)" : "var(--fg-2)",
-                border: selected
-                  ? "1.5px solid var(--accent)"
-                  : "1px solid var(--border-subtle)",
-                cursor: "pointer",
-                transition:
-                  "background-color 150ms, border-color 150ms, color 150ms",
-              }}
-            >
-              {day}
-            </button>
-          );
-        })}
-      </div>
+      <fieldset style={{ border: 0, margin: 0, padding: 0, minInlineSize: 0 }}>
+        <legend className="sr-only">Día de vencimiento</legend>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(7, 1fr)",
+            gap: 4,
+          }}
+        >
+          {DAYS.map((day) => {
+            const selected = value === day;
+            return (
+              <button
+                key={day}
+                type="button"
+                aria-pressed={selected}
+                aria-label={`Día ${day}`}
+                onClick={() => onChange(day)}
+                style={{
+                  aspectRatio: "1",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  borderRadius: 8,
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 13,
+                  fontWeight: selected ? 700 : 500,
+                  background: selected ? "var(--accent)" : "var(--bg-elevated)",
+                  color: selected ? "var(--accent-foreground)" : "var(--fg-2)",
+                  border: selected
+                    ? "1.5px solid var(--accent)"
+                    : "1px solid var(--border-subtle)",
+                  cursor: "pointer",
+                  transition:
+                    "background-color 150ms, border-color 150ms, color 150ms",
+                }}
+              >
+                {day}
+              </button>
+            );
+          })}
+        </div>
+      </fieldset>
     </div>
   );
 }

--- a/src/app/(app)/expenses/_components/fijo-item.tsx
+++ b/src/app/(app)/expenses/_components/fijo-item.tsx
@@ -124,7 +124,7 @@ export function FijoItem({
             fontFamily: "var(--font-sans)",
           }}
         >
-          Vence día {fi.fixed_expense_templates.due_day}
+          Vence día {fi.due_day ?? fi.fixed_expense_templates.due_day}
         </div>
         {hasOverride && (
           <span
@@ -149,7 +149,7 @@ export function FijoItem({
               display: "inline-block",
               marginTop: 3,
               background: "var(--status-danger-subtle)",
-              color: "var(--status-danger)",
+              color: "var(--status-danger-text)",
               fontSize: 10,
               fontWeight: 600,
               borderRadius: 4,
@@ -237,7 +237,7 @@ export function FijoItem({
                 role="alert"
                 style={{
                   fontSize: 11,
-                  color: "var(--status-danger)",
+                  color: "var(--status-danger-text)",
                   fontFamily: "var(--font-sans)",
                 }}
               >
@@ -283,14 +283,12 @@ export function FijoItem({
               )}
               <Button
                 variant="ghost"
-                size="icon"
                 onClick={handleStartEdit}
                 title="Editar monto"
                 aria-label="Editar monto"
                 style={{
-                  padding: "0 4px",
-                  minWidth: 44,
-                  minHeight: 44,
+                  height: 32,
+                  padding: "0 8px",
                   justifyContent: "flex-end",
                 }}
               >
@@ -332,9 +330,9 @@ export function FijoItem({
             height: 28,
             paddingInline: 10,
             borderRadius: 8,
-            border: `1.5px solid var(--status-danger)`,
+            border: `1.5px solid var(--status-danger-text)`,
             background: "var(--status-danger-subtle)",
-            color: "var(--status-danger)",
+            color: "var(--status-danger-text)",
             fontSize: 11,
             fontWeight: 600,
             fontFamily: "var(--font-sans)",
@@ -346,18 +344,38 @@ export function FijoItem({
         </Button>
       )}
 
-      {/* Right: paid toggle */}
-      <Switch
-        checked={fi.paid}
-        onCheckedChange={(checked) =>
-          startTransition(async () => {
-            await toggleFixedExpenseInstance(fi.id, checked);
-            queryClient.invalidateQueries({ queryKey: ["monthly-data"] });
-          })
-        }
-        disabled={editing || amountMutation.isPending}
-        aria-label={fi.paid ? "Marcar como no pagado" : "Marcar como pagado"}
-      />
+      {/* Right: paid toggle with visible status label */}
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: 3,
+          flexShrink: 0,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 10,
+            fontWeight: 600,
+            fontFamily: "var(--font-sans)",
+            color: fi.paid ? "var(--status-success-text)" : "var(--fg-3)",
+          }}
+        >
+          {fi.paid ? "Pagado" : "Sin pagar"}
+        </span>
+        <Switch
+          checked={fi.paid}
+          onCheckedChange={(checked) =>
+            startTransition(async () => {
+              await toggleFixedExpenseInstance(fi.id, checked);
+              queryClient.invalidateQueries({ queryKey: ["monthly-data"] });
+            })
+          }
+          disabled={editing || amountMutation.isPending}
+          aria-label={fi.paid ? "Marcar como no pagado" : "Marcar como pagado"}
+        />
+      </div>
     </div>
   );
 }

--- a/src/app/(app)/expenses/_components/segmented-control.tsx
+++ b/src/app/(app)/expenses/_components/segmented-control.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import type { Tab } from "@/lib/queries/use-expense-save";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+export type ExpenseFilter = Tab | "todo";
 
 export const TAB_LABEL: Record<Tab, string> = {
   cuotas: "Cuotas",
@@ -15,35 +16,59 @@ export const TAB_TESTID: Record<Tab, string> = {
   variables: "tab-compras",
 };
 
+const FILTER_ORDER: readonly ExpenseFilter[] = [
+  "todo",
+  "cuotas",
+  "fijos",
+  "variables",
+];
+
+const FILTER_LABEL: Record<ExpenseFilter, string> = {
+  todo: "Todo",
+  ...TAB_LABEL,
+};
+
+const FILTER_TESTID: Record<ExpenseFilter, string> = {
+  todo: "tab-todo",
+  ...TAB_TESTID,
+};
+
 export function SegmentedControl({
   active,
   onChange,
 }: {
-  readonly active: Tab;
-  readonly onChange: (t: Tab) => void;
+  readonly active: ExpenseFilter;
+  readonly onChange: (filter: ExpenseFilter) => void;
 }) {
   return (
     <div
-      style={{
-        padding: "10px 16px",
-        background: "var(--bg-elevated)",
-        borderBottom: "1px solid var(--border-subtle)",
-      }}
+      role="tablist"
+      aria-label="Filtrar gastos por tipo"
+      className="flex w-full gap-1 rounded-full p-1"
+      style={{ background: "var(--bg-sunken)" }}
     >
-      <Tabs value={active} onValueChange={(v) => onChange(v as Tab)}>
-        <TabsList className="w-full">
-          {(["cuotas", "fijos", "variables"] as Tab[]).map((t) => (
-            <TabsTrigger
-              key={t}
-              value={t}
-              data-testid={TAB_TESTID[t]}
-              className="flex-1"
-            >
-              {TAB_LABEL[t]}
-            </TabsTrigger>
-          ))}
-        </TabsList>
-      </Tabs>
+      {FILTER_ORDER.map((f) => {
+        const isActive = active === f;
+        return (
+          <button
+            key={f}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            data-testid={FILTER_TESTID[f]}
+            onClick={() => onChange(f)}
+            className="flex-1 cursor-pointer rounded-full px-2 py-1.5 text-[13px] font-semibold transition-colors"
+            style={{
+              background: isActive ? "var(--bg-elevated)" : "transparent",
+              color: isActive ? "var(--accent)" : "var(--fg-2)",
+              boxShadow: isActive ? "var(--shadow-sm)" : "none",
+              fontFamily: "var(--font-sans)",
+            }}
+          >
+            {FILTER_LABEL[f]}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/src/app/(app)/expenses/_components/variable-item.tsx
+++ b/src/app/(app)/expenses/_components/variable-item.tsx
@@ -1,6 +1,6 @@
 import { PersonAvatar } from "@/components/shared/avatar";
 import { Card, CardContent } from "@/components/ui/card";
-import { formatARS } from "@/lib/utils";
+import { formatARS, formatDayMonth } from "@/lib/utils";
 import { useMonthlyData } from "@/lib/queries/use-monthly-data";
 
 type MonthlyData = NonNullable<ReturnType<typeof useMonthlyData>["data"]>;
@@ -23,12 +23,30 @@ export function VariableItem({
           person={getPerson(v.user_id)}
           size="md"
         />
-        <div style={{ flex: 1 }}>
-          <div style={{ fontSize: 14, fontWeight: 500, color: "var(--fg-1)" }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div
+            style={{
+              fontSize: 14,
+              fontWeight: 500,
+              color: "var(--fg-1)",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
             {v.description}
           </div>
-          <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 2 }}>
-            <span style={{ fontSize: 12, color: "var(--fg-3)" }}>{v.date}</span>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              marginTop: 2,
+            }}
+          >
+            <span style={{ fontSize: 12, color: "var(--fg-3)" }}>
+              {formatDayMonth(v.date)}
+            </span>
             {!v.is_shared && (
               <span
                 style={{

--- a/src/app/(app)/expenses/page.tsx
+++ b/src/app/(app)/expenses/page.tsx
@@ -664,6 +664,13 @@ const PARAM_TO_FILTER: Record<string, ExpenseFilter> = {
   compras: "variables",
 };
 
+function flowStepToAddTab(step: FlowState["step"]): Tab | null {
+  if (step === "cuota-form") return "cuotas";
+  if (step === "new-service") return "fijos";
+  if (step === "compra-form") return "variables";
+  return null;
+}
+
 function ExpensesView() {
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -695,14 +702,7 @@ function ExpensesView() {
   }, [filter, filterCategory]);
 
   // Map flow steps to AddSheet tab — must be computed before useExpenseSave
-  const addSheetTab: Tab | null =
-    flow.step === "cuota-form"
-      ? "cuotas"
-      : flow.step === "new-service"
-        ? "fijos"
-        : flow.step === "compra-form"
-          ? "variables"
-          : null;
+  const addSheetTab: Tab | null = flowStepToAddTab(flow.step);
 
   const { save, saveError } = useExpenseSave(
     addSheetTab ?? (filter === "todo" ? "cuotas" : filter),

--- a/src/app/(app)/expenses/page.tsx
+++ b/src/app/(app)/expenses/page.tsx
@@ -1,7 +1,11 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useEffect, Suspense } from "react";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useForm, useWatch } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
 import { FAB as Fab } from "@/components/shared/fab";
 import { formatARS, getMonthDate, getInitials, cn } from "@/lib/utils";
 import { effectiveFixedAmount } from "@/lib/utils/balance";
@@ -15,16 +19,20 @@ import {
 import { useExpenseSave, type Tab } from "@/lib/queries/use-expense-save";
 import {
   updateFixedExpenseInstanceAmount,
+  updateFixedExpenseInstanceDueDay,
   toggleFixedExpenseInstance,
   confirmAllFixedExpenseInstances,
 } from "@/lib/actions/expenses";
 import { CuotaItem } from "./_components/cuota-item";
 import { FijoItem } from "./_components/fijo-item";
 import { VariableItem } from "./_components/variable-item";
-import { TAB_LABEL, TAB_TESTID } from "./_components/segmented-control";
+import {
+  SegmentedControl,
+  type ExpenseFilter,
+} from "./_components/segmented-control";
 import { AddSheet } from "./_components/add-sheet";
+import { DueDayPicker } from "./_components/due-day-picker";
 import { ResponsiveModal } from "@/components/shared/responsive-modal";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 
@@ -33,6 +41,20 @@ const TAB_DESCRIPTIONS: Record<Tab, string> = {
   fijos: "Agua, luz, expensas y servicios que se repiten cada mes",
   variables: "Gastos puntuales del mes, compartidos o personales",
 };
+
+// ── SCHEMAS ───────────────────────────────────────────────────────────────────
+
+const dueDaySchema = z.object({
+  due_day: z
+    .string()
+    .min(1, "Requerido")
+    .refine((v) => {
+      const n = Number.parseInt(v, 10);
+      return !Number.isNaN(n) && n >= 1 && n <= 31;
+    }, "Debe ser un número entre 1 y 31"),
+});
+
+type DueDayFields = z.infer<typeof dueDaySchema>;
 
 // ── FLOW STATE ────────────────────────────────────────────────────────────────
 
@@ -61,6 +83,102 @@ function TabDescription({ tab }: { tab: Tab }) {
     >
       {TAB_DESCRIPTIONS[tab]}
     </p>
+  );
+}
+
+function SectionLabel({ children }: { readonly children: string }) {
+  return (
+    <div
+      className="mb-1.5 px-1 text-[11px] font-bold uppercase"
+      style={{
+        color: "var(--fg-3)",
+        letterSpacing: "0.05em",
+        fontFamily: "var(--font-sans)",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function FilterFunnelIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="var(--fg-2)"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+    </svg>
+  );
+}
+
+// ── CATEGORY FILTER SHEET ────────────────────────────────────────────────────
+
+type Categories = NonNullable<ReturnType<typeof useCategories>["data"]>;
+
+interface CategoryFilterSheetProps {
+  readonly categories: Categories;
+  readonly filterCategory: string | null;
+  readonly onSelect: (categoryId: string | null) => void;
+  readonly onClose: () => void;
+}
+
+function CategoryFilterSheet({
+  categories,
+  filterCategory,
+  onSelect,
+  onClose,
+}: CategoryFilterSheetProps) {
+  return (
+    <ResponsiveModal
+      open
+      onOpenChange={(open) => !open && onClose()}
+      title="Filtrar por categoría"
+      data-testid="category-filter-sheet"
+    >
+      <div className="flex flex-wrap gap-1.5 pb-4">
+        <button
+          onClick={() => onSelect(null)}
+          className="cursor-pointer rounded-[20px] text-xs font-semibold"
+          style={{
+            padding: "6px 14px",
+            border: "1px solid var(--border-subtle)",
+            background:
+              filterCategory === null ? "var(--accent)" : "var(--bg-sunken)",
+            color: filterCategory === null ? "#fff" : "var(--fg-2)",
+            fontFamily: "var(--font-sans)",
+          }}
+        >
+          Todos
+        </button>
+        {categories.map((cat) => (
+          <button
+            key={cat.id}
+            onClick={() => onSelect(filterCategory === cat.id ? null : cat.id)}
+            className="cursor-pointer rounded-[20px] text-xs font-semibold"
+            style={{
+              padding: "6px 14px",
+              border: "1px solid var(--border-subtle)",
+              background:
+                filterCategory === cat.id
+                  ? "var(--accent)"
+                  : "var(--bg-sunken)",
+              color: filterCategory === cat.id ? "#fff" : "var(--fg-2)",
+              fontFamily: "var(--font-sans)",
+            }}
+          >
+            {cat.icon} {cat.name}
+          </button>
+        ))}
+      </div>
+    </ResponsiveModal>
   );
 }
 
@@ -246,9 +364,9 @@ function ServiceListSheet({
                 <span
                   className="shrink-0 rounded-md px-2 py-0.5 text-xs font-semibold"
                   style={{
-                    color: "var(--color-teal)",
+                    color: "var(--status-success-text)",
                     background:
-                      "color-mix(in srgb, var(--color-teal) 12%, transparent)",
+                      "color-mix(in srgb, var(--status-success) 12%, transparent)",
                     fontFamily: "var(--font-sans)",
                   }}
                 >
@@ -294,12 +412,41 @@ function EditServiceSheet({
 }: EditServiceSheetProps) {
   const queryClient = useQueryClient();
   const currentAmount = effectiveFixedAmount(instance);
+  const currentDueDay =
+    instance.due_day ?? instance.fixed_expense_templates.due_day;
   const [draft, setDraft] = useState(String(currentAmount));
   const [fieldError, setFieldError] = useState<string | null>(null);
+
+  const {
+    register,
+    control,
+    setValue,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<DueDayFields>({
+    resolver: zodResolver(dueDaySchema),
+    defaultValues: { due_day: String(currentDueDay) },
+  });
+
+  const dueDayRaw = useWatch({ control, name: "due_day" });
+  const dueDayValue = (() => {
+    const n = Number.parseInt(dueDayRaw ?? "", 10);
+    return Number.isFinite(n) && n >= 1 && n <= 31 ? n : null;
+  })();
 
   const amountMutation = useMutation({
     mutationFn: ({ id, amount }: { id: string; amount: number | null }) =>
       updateFixedExpenseInstanceAmount(id, amount),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["monthly-data", coupleId, month],
+      });
+    },
+  });
+
+  const dueDayMutation = useMutation({
+    mutationFn: ({ id, dueDay }: { id: string; dueDay: number }) =>
+      updateFixedExpenseInstanceDueDay(id, dueDay),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ["monthly-data", coupleId, month],
@@ -317,20 +464,36 @@ function EditServiceSheet({
     },
   });
 
-  function handleSave() {
+  function handleSave(values: DueDayFields) {
     const parsed = parseAmount(draft);
     if (!Number.isFinite(parsed) || parsed <= 0) {
       setFieldError("El monto debe ser mayor a cero");
       return;
     }
     setFieldError(null);
+    const dueDay = Number.parseInt(values.due_day, 10);
+
     amountMutation.mutate(
       { id: instance.id, amount: parsed },
-      { onSuccess: onClose },
+      {
+        onSuccess: () => {
+          if (dueDay !== currentDueDay) {
+            dueDayMutation.mutate(
+              { id: instance.id, dueDay },
+              { onSuccess: onClose },
+            );
+          } else {
+            onClose();
+          }
+        },
+      },
     );
   }
 
-  const isPending = amountMutation.isPending || toggleMutation.isPending;
+  const isPending =
+    amountMutation.isPending ||
+    toggleMutation.isPending ||
+    dueDayMutation.isPending;
   const name = instance.fixed_expense_templates.description;
 
   return (
@@ -340,115 +503,196 @@ function EditServiceSheet({
       title={name}
       data-testid="edit-service-sheet"
     >
-      {/* Amount edit */}
-      <div className="mb-3.5">
-        <label
-          htmlFor="edit-service-amount"
-          className="mb-1.5 block text-[13px] font-medium"
-          style={{ color: "var(--fg-2)", fontFamily: "var(--font-sans)" }}
-        >
-          Monto este mes
-        </label>
-        <div
-          className="flex items-center overflow-hidden"
-          style={{
-            background: "var(--bg-sunken)",
-            borderRadius: 10,
-            border: "1.5px solid var(--border-default)",
-          }}
-        >
-          <span
-            aria-hidden
-            className="text-base font-semibold"
+      <form onSubmit={handleSubmit(handleSave)}>
+        {/* Amount edit */}
+        <div className="mb-3.5">
+          <label
+            htmlFor="edit-service-amount"
+            className="mb-1.5 block text-[13px] font-medium"
+            style={{ color: "var(--fg-2)", fontFamily: "var(--font-sans)" }}
+          >
+            Monto este mes
+          </label>
+          <div
+            className="flex items-center overflow-hidden focus-within:ring-2 focus-within:ring-(--accent)"
             style={{
-              padding: "10px 6px 10px 12px",
-              color: "var(--fg-3)",
-              fontFamily: "var(--font-mono)",
+              background: "var(--bg-sunken)",
+              borderRadius: 10,
+              border: "1.5px solid var(--border-default)",
             }}
           >
-            $
-          </span>
+            <span
+              aria-hidden
+              className="text-base font-semibold"
+              style={{
+                padding: "10px 6px 10px 12px",
+                color: "var(--fg-3)",
+                fontFamily: "var(--font-mono)",
+              }}
+            >
+              $
+            </span>
+            <input
+              id="edit-service-amount"
+              type="text"
+              value={draft}
+              onChange={(e) => {
+                setDraft(e.target.value);
+                setFieldError(null);
+              }}
+              inputMode="decimal"
+              className="flex-1 text-base font-semibold"
+              style={{
+                border: "none",
+                background: "transparent",
+                padding: "10px 12px 10px 4px",
+                fontFamily: "var(--font-mono)",
+                outline: "none",
+                color: "var(--fg-1)",
+              }}
+            />
+          </div>
+          {instance.amount_override == null && (
+            <div
+              className="mt-1 text-xs"
+              style={{ color: "var(--fg-3)", fontFamily: "var(--font-sans)" }}
+            >
+              Default: {formatARS(instance.fixed_expense_templates.amount)}
+            </div>
+          )}
+          {fieldError && (
+            <div
+              role="alert"
+              className="mt-1 text-xs"
+              style={{
+                color: "var(--status-danger-text)",
+                fontFamily: "var(--font-sans)",
+              }}
+            >
+              {fieldError}
+            </div>
+          )}
+        </div>
+
+        {/* Due day edit */}
+        <div className="mb-3.5">
+          <label
+            htmlFor="edit-service-due-day"
+            className="mb-1.5 block text-[13px] font-medium"
+            style={{ color: "var(--fg-2)", fontFamily: "var(--font-sans)" }}
+          >
+            Día de vencimiento
+          </label>
+          {/* Visually-hidden native input keeps the field addressable while
+              the grid is the visual control. */}
           <input
-            id="edit-service-amount"
+            id="edit-service-due-day"
+            data-testid="edit-service-due-day"
             type="text"
-            value={draft}
-            onChange={(e) => {
-              setDraft(e.target.value);
-              setFieldError(null);
-            }}
-            inputMode="decimal"
-            className="flex-1 text-base font-semibold"
-            style={{
-              border: "none",
-              background: "transparent",
-              padding: "10px 12px 10px 4px",
-              fontFamily: "var(--font-mono)",
-              outline: "none",
-              color: "var(--fg-1)",
-            }}
+            inputMode="numeric"
+            className="sr-only"
+            {...register("due_day")}
+          />
+          <DueDayPicker
+            value={dueDayValue}
+            onChange={(day) =>
+              setValue("due_day", String(day), {
+                shouldValidate: true,
+                shouldDirty: true,
+              })
+            }
+          />
+          {errors.due_day && (
+            <div
+              role="alert"
+              className="mt-1 text-xs"
+              style={{
+                color: "var(--status-danger-text)",
+                fontFamily: "var(--font-sans)",
+              }}
+            >
+              {errors.due_day.message}
+            </div>
+          )}
+        </div>
+
+        {/* Paid toggle */}
+        <div className="mb-5 flex items-center justify-between">
+          <span
+            className="text-[13px] font-medium"
+            style={{ color: "var(--fg-2)", fontFamily: "var(--font-sans)" }}
+          >
+            Ya lo pagué
+          </span>
+          <Switch
+            checked={instance.paid}
+            onCheckedChange={(checked) =>
+              toggleMutation.mutate({ id: instance.id, paid: checked })
+            }
+            disabled={isPending}
+            aria-label={
+              instance.paid ? "Marcar como no pagado" : "Marcar como pagado"
+            }
           />
         </div>
-        {instance.amount_override == null && (
-          <div
-            className="mt-1 text-xs"
-            style={{ color: "var(--fg-3)", fontFamily: "var(--font-sans)" }}
-          >
-            Default: {formatARS(instance.fixed_expense_templates.amount)}
-          </div>
-        )}
-        {fieldError && (
-          <div
-            role="alert"
-            className="mt-1 text-xs"
-            style={{
-              color: "var(--status-danger)",
-              fontFamily: "var(--font-sans)",
-            }}
-          >
-            {fieldError}
-          </div>
-        )}
-      </div>
 
-      {/* Paid toggle */}
-      <div className="mb-5 flex items-center justify-between">
-        <span
-          className="text-[13px] font-medium"
-          style={{ color: "var(--fg-2)", fontFamily: "var(--font-sans)" }}
-        >
-          Ya lo pagué
-        </span>
-        <Switch
-          checked={instance.paid}
-          onCheckedChange={(checked) =>
-            toggleMutation.mutate({ id: instance.id, paid: checked })
-          }
+        <Button
+          type="submit"
           disabled={isPending}
-          aria-label={
-            instance.paid ? "Marcar como no pagado" : "Marcar como pagado"
-          }
-        />
-      </div>
-
-      <Button
-        type="button"
-        onClick={handleSave}
-        disabled={isPending}
-        className="w-full"
-        style={{ opacity: isPending ? 0.7 : 1 }}
-      >
-        Guardar
-      </Button>
+          className="w-full"
+          style={{ opacity: isPending ? 0.7 : 1 }}
+        >
+          Guardar
+        </Button>
+      </form>
     </ResponsiveModal>
   );
 }
 
 // ── PAGE ──────────────────────────────────────────────────────────────────────
 
-export default function ExpensesPage() {
-  const [tab, setTab] = useState<Tab>("cuotas");
+// Maps the internal filter value to a user-facing URL param and back.
+const FILTER_TO_PARAM: Record<ExpenseFilter, string | null> = {
+  todo: null,
+  cuotas: "cuotas",
+  fijos: "servicios",
+  variables: "compras",
+};
+const PARAM_TO_FILTER: Record<string, ExpenseFilter> = {
+  cuotas: "cuotas",
+  servicios: "fijos",
+  compras: "variables",
+};
+
+function ExpensesView() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const [filter, setFilter] = useState<ExpenseFilter>(
+    () => PARAM_TO_FILTER[searchParams.get("tipo") ?? ""] ?? "todo",
+  );
   const [flow, setFlow] = useState<FlowState>({ step: "idle" });
-  const [filterCategory, setFilterCategory] = useState<string | null>(null);
+  const [filterCategory, setFilterCategory] = useState<string | null>(() =>
+    searchParams.get("cat"),
+  );
+  const [filterSheetOpen, setFilterSheetOpen] = useState(false);
+
+  // Sync filter + category to the URL (?tipo=...&cat=...). Defaults = clean URL.
+  useEffect(() => {
+    const params = new URLSearchParams(Array.from(searchParams.entries()));
+    const tipo = FILTER_TO_PARAM[filter];
+    if (tipo) params.set("tipo", tipo);
+    else params.delete("tipo");
+    if (filterCategory) params.set("cat", filterCategory);
+    else params.delete("cat");
+    const next = params.toString();
+    if (next !== searchParams.toString()) {
+      router.replace(next ? `${pathname}?${next}` : pathname, {
+        scroll: false,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- URL sync keys on filter/category; router/searchParams/pathname are stable and excluded to avoid loops
+  }, [filter, filterCategory]);
 
   // Map flow steps to AddSheet tab — must be computed before useExpenseSave
   const addSheetTab: Tab | null =
@@ -460,11 +704,18 @@ export default function ExpensesPage() {
           ? "variables"
           : null;
 
-  const { save, saveError } = useExpenseSave(addSheetTab ?? tab);
+  const { save, saveError } = useExpenseSave(
+    addSheetTab ?? (filter === "todo" ? "cuotas" : filter),
+  );
 
-  function handleTabChange(newTab: Tab) {
-    setTab(newTab);
+  function handleFilterChange(newFilter: ExpenseFilter) {
+    setFilter(newFilter);
     setFilterCategory(null);
+  }
+
+  function handleCategorySelect(categoryId: string | null) {
+    setFilterCategory(categoryId);
+    setFilterSheetOpen(false);
   }
 
   const { data: member } = useCoupleMember();
@@ -475,20 +726,6 @@ export default function ExpensesPage() {
     member?.user_id ?? null,
   );
   const { data: categories = [] } = useCategories(coupleId);
-
-  const [categoryRowOverflows, setCategoryRowOverflows] = useState(false);
-  const categoryRowRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const el = categoryRowRef.current;
-    if (!el) return;
-    const check = () =>
-      setCategoryRowOverflows(el.scrollWidth > el.clientWidth);
-    check();
-    const ro = new ResizeObserver(check);
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, [categories]);
 
   const getPersonInitials = (userId: string) => {
     const p = profiles.find((pr) => pr.user_id === userId);
@@ -545,6 +782,14 @@ export default function ExpensesPage() {
     ? allVariables.filter((v) => v.category_id === filterCategory)
     : allVariables;
 
+  const showTodo = filter === "todo";
+  const cuotasVisible = filter === "cuotas" || (showTodo && cuotas.length > 0);
+  const fijosVisible = filter === "fijos" || (showTodo && fijos.length > 0);
+  const variablesVisible =
+    filter === "variables" || (showTodo && variables.length > 0);
+  const allEmpty =
+    cuotas.length === 0 && fijos.length === 0 && variables.length === 0;
+
   // Resolve the active fixed instance for edit-service step
   const activeInstance =
     flow.step === "edit-service"
@@ -559,100 +804,81 @@ export default function ExpensesPage() {
         background: "var(--bg-base)",
       }}
     >
-      <Tabs
-        value={tab}
-        onValueChange={(v) => handleTabChange(v as Tab)}
-        className="flex flex-1 flex-col"
+      <div
+        style={{
+          background: "var(--bg-elevated)",
+          borderBottom: "1px solid var(--border-subtle)",
+          paddingTop: 14,
+        }}
       >
-        <div
-          style={{
-            background: "var(--bg-elevated)",
-            borderBottom: "1px solid var(--border-subtle)",
-            paddingTop: 14,
-          }}
-        >
-          <div className="mx-auto w-full max-w-3xl">
-            <h1
-              className="m-0 px-5 pb-[10px] text-lg font-bold"
-              style={{
-                color: "var(--fg-1)",
-                fontFamily: "var(--font-sans)",
-              }}
-            >
-              Gastos
-            </h1>
-            <div className="px-4 pb-2.5">
-              <TabsList className="w-full bg-(--bg-sunken)">
-                {(["cuotas", "fijos", "variables"] as Tab[]).map((t) => (
-                  <TabsTrigger
-                    key={t}
-                    value={t}
-                    data-testid={TAB_TESTID[t]}
-                    className="flex-1 text-(--fg-2) data-[state=active]:bg-(--bg-elevated) data-[state=active]:font-semibold data-[state=active]:text-(--accent) data-[state=active]:shadow-sm"
-                  >
-                    {TAB_LABEL[t]}
-                  </TabsTrigger>
-                ))}
-              </TabsList>
+        <div className="mx-auto w-full max-w-3xl">
+          <h1
+            className="m-0 px-5 pb-[10px] text-lg font-bold"
+            style={{
+              color: "var(--fg-1)",
+              fontFamily: "var(--font-sans)",
+            }}
+          >
+            Gastos
+          </h1>
+          <div className="flex items-center gap-2 px-4 pb-2.5">
+            <div className="flex-1">
+              <SegmentedControl active={filter} onChange={handleFilterChange} />
             </div>
-            <TabDescription tab={tab} />
             {categories.length > 0 && (
-              <div
-                ref={categoryRowRef}
-                className={cn(
-                  "flex flex-nowrap gap-1.5 overflow-x-auto px-4 pe-8 pt-2 pb-2.5 [scrollbar-width:none] lg:flex-wrap lg:overflow-x-visible lg:pe-0",
-                  categoryRowOverflows && "category-filter-scroll",
-                )}
+              <button
+                type="button"
+                onClick={() => setFilterSheetOpen(true)}
+                aria-label="Más filtros"
+                data-testid="expenses-filters-button"
+                className="relative flex shrink-0 cursor-pointer items-center justify-center rounded-xl"
+                style={{
+                  width: 40,
+                  height: 40,
+                  background: "var(--bg-sunken)",
+                  border: "1px solid var(--border-subtle)",
+                }}
               >
-                <button
-                  onClick={() => setFilterCategory(null)}
-                  className="flex-shrink-0 cursor-pointer rounded-[20px] text-xs font-semibold"
-                  style={{
-                    padding: "4px 12px",
-                    border: "1px solid var(--border-subtle)",
-                    background:
-                      filterCategory === null
-                        ? "var(--accent)"
-                        : "var(--bg-sunken)",
-                    color: filterCategory === null ? "#fff" : "var(--fg-2)",
-                    fontFamily: "var(--font-sans)",
-                  }}
-                >
-                  Todos
-                </button>
-                {categories.map((cat) => (
-                  <button
-                    key={cat.id}
-                    onClick={() =>
-                      setFilterCategory(
-                        filterCategory === cat.id ? null : cat.id,
-                      )
-                    }
-                    className="flex-shrink-0 cursor-pointer rounded-[20px] text-xs font-semibold"
+                <FilterFunnelIcon />
+                {filterCategory !== null && (
+                  <span
+                    className="absolute flex items-center justify-center rounded-full text-[10px] font-bold"
                     style={{
-                      padding: "4px 12px",
-                      border: "1px solid var(--border-subtle)",
-                      background:
-                        filterCategory === cat.id
-                          ? "var(--accent)"
-                          : "var(--bg-sunken)",
-                      color: filterCategory === cat.id ? "#fff" : "var(--fg-2)",
+                      top: -4,
+                      right: -4,
+                      width: 16,
+                      height: 16,
+                      background: "var(--accent)",
+                      color: "var(--accent-foreground)",
                       fontFamily: "var(--font-sans)",
                     }}
                   >
-                    {cat.icon} {cat.name}
-                  </button>
-                ))}
-              </div>
+                    1
+                  </span>
+                )}
+              </button>
             )}
           </div>
+          {!showTodo && <TabDescription tab={filter} />}
         </div>
+      </div>
 
-        <div style={{ flex: 1, overflowY: "auto" }}>
+      <div style={{ flex: 1, overflowY: "auto" }}>
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 px-4 py-3">
+          {showTodo && allEmpty && (
+            <div
+              className="py-12 text-center text-sm"
+              style={{ color: "var(--fg-3)", fontFamily: "var(--font-sans)" }}
+            >
+              Sin gastos este mes. Usá el + para agregar.
+            </div>
+          )}
+
           {/* CUOTAS */}
-          <TabsContent value="cuotas" className="mt-0">
-            <div className="mx-auto flex w-full max-w-3xl flex-col gap-2 px-4 py-3">
-              {cuotas.length === 0 && (
+          {cuotasVisible && (
+            <div>
+              {showTodo && <SectionLabel>Cuotas</SectionLabel>}
+              {filter === "cuotas" && cuotas.length === 0 && (
                 <div
                   className="py-12 text-center text-sm"
                   style={{
@@ -675,12 +901,13 @@ export default function ExpensesPage() {
                 ))}
               </ul>
             </div>
-          </TabsContent>
+          )}
 
           {/* FIJOS */}
-          <TabsContent value="fijos" className="mt-0">
-            <div className="mx-auto w-full max-w-3xl px-4 py-3">
-              {fijos.length === 0 && (
+          {fijosVisible && (
+            <div>
+              {showTodo && <SectionLabel>Servicios</SectionLabel>}
+              {filter === "fijos" && fijos.length === 0 && (
                 <div
                   className="text-center text-sm"
                   style={{
@@ -707,10 +934,10 @@ export default function ExpensesPage() {
                           confirmAllMutation.isPending && "opacity-50",
                         )}
                         style={{
-                          border: `1.5px solid var(--color-coral)`,
+                          border: `1.5px solid var(--status-danger-text)`,
                           background:
-                            "color-mix(in srgb, var(--color-coral) 10%, transparent)",
-                          color: "var(--color-coral)",
+                            "color-mix(in srgb, var(--status-danger) 10%, transparent)",
+                          color: "var(--status-danger-text)",
                         }}
                       >
                         Confirmar todos
@@ -772,12 +999,13 @@ export default function ExpensesPage() {
                 </>
               )}
             </div>
-          </TabsContent>
+          )}
 
           {/* VARIABLES */}
-          <TabsContent value="variables" className="mt-0">
-            <div className="mx-auto flex w-full max-w-3xl flex-col gap-2 px-4 py-3">
-              {variables.length === 0 && (
+          {variablesVisible && (
+            <div>
+              {showTodo && <SectionLabel>Compras</SectionLabel>}
+              {filter === "variables" && variables.length === 0 && (
                 <div
                   className="text-center text-sm"
                   style={{
@@ -801,9 +1029,18 @@ export default function ExpensesPage() {
                 ))}
               </ul>
             </div>
-          </TabsContent>
+          )}
         </div>
-      </Tabs>
+      </div>
+
+      {filterSheetOpen && (
+        <CategoryFilterSheet
+          categories={categories}
+          filterCategory={filterCategory}
+          onSelect={handleCategorySelect}
+          onClose={() => setFilterSheetOpen(false)}
+        />
+      )}
 
       {flow.step === "idle" && (
         <Fab
@@ -857,5 +1094,13 @@ export default function ExpensesPage() {
         />
       )}
     </div>
+  );
+}
+
+export default function ExpensesPage() {
+  return (
+    <Suspense fallback={null}>
+      <ExpensesView />
+    </Suspense>
   );
 }

--- a/src/app/(app)/history/_components/month-card.tsx
+++ b/src/app/(app)/history/_components/month-card.tsx
@@ -159,8 +159,8 @@ export function MonthCard({
             fontWeight: 700,
             color:
               balance.debtAmount > 0
-                ? "var(--status-danger)"
-                : "var(--status-success)",
+                ? "var(--status-danger-text)"
+                : "var(--status-success-text)",
           }}
         >
           {formatARS(balance.totalExpenses)}

--- a/src/app/(app)/history/_components/month-detail.tsx
+++ b/src/app/(app)/history/_components/month-detail.tsx
@@ -142,8 +142,8 @@ export function MonthDetail({
                   fontWeight: 700,
                   color:
                     balance.debtAmount > 0
-                      ? "var(--status-danger)"
-                      : "var(--status-success)",
+                      ? "var(--status-danger-text)"
+                      : "var(--status-success-text)",
                   letterSpacing: "-0.02em",
                 }}
               >

--- a/src/app/(app)/settings/_components/no-couple-card.tsx
+++ b/src/app/(app)/settings/_components/no-couple-card.tsx
@@ -52,7 +52,7 @@ export function NoCoupleCard({
             aria-live="polite"
             style={{
               fontSize: 12,
-              color: "var(--status-danger)",
+              color: "var(--status-danger-text)",
               fontFamily: "var(--font-sans)",
             }}
           >

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -155,7 +155,7 @@ export default function SettingsPage() {
           className="text-sm"
           style={{ color: "var(--fg-3)", fontFamily: "var(--font-sans)" }}
         >
-          Cargando...
+          Cargando…
         </span>
       </div>
     );
@@ -338,8 +338,8 @@ export default function SettingsPage() {
                               className="mt-1.5 text-xs"
                               style={{
                                 color: inviteMsg.includes("✓")
-                                  ? "var(--status-success)"
-                                  : "var(--status-danger)",
+                                  ? "var(--status-success-text)"
+                                  : "var(--status-danger-text)",
                                 fontFamily: "var(--font-sans)",
                               }}
                             >
@@ -439,7 +439,7 @@ export default function SettingsPage() {
                           style={{ fontFamily: "var(--font-sans)" }}
                         >
                           {isPending
-                            ? "Generando..."
+                            ? "Generando…"
                             : "Generar link de invitación"}
                         </Button>
                       )}
@@ -448,7 +448,7 @@ export default function SettingsPage() {
                           aria-live="polite"
                           className="mt-1.5 text-xs"
                           style={{
-                            color: "var(--status-danger)",
+                            color: "var(--status-danger-text)",
                             fontFamily: "var(--font-sans)",
                           }}
                         >
@@ -494,7 +494,7 @@ export default function SettingsPage() {
             >
               <div style={{ padding: "14px 16px" }}>
                 <div
-                  className="flex items-center overflow-hidden"
+                  className="flex items-center overflow-hidden focus-within:ring-2 focus-within:ring-(--accent)"
                   style={{
                     background: "var(--bg-sunken)",
                     borderRadius: 10,
@@ -554,7 +554,7 @@ export default function SettingsPage() {
                   className="w-full"
                   style={{ fontFamily: "var(--font-sans)" }}
                 >
-                  {isPending ? "Guardando..." : "Guardar ingreso"}
+                  {isPending ? "Guardando…" : "Guardar ingreso"}
                 </Button>
               </div>
             </div>
@@ -611,7 +611,7 @@ export default function SettingsPage() {
               className="w-full justify-start rounded-none text-sm font-medium"
               style={{
                 padding: "14px 16px",
-                color: "var(--status-danger)",
+                color: "var(--status-danger-text)",
                 fontFamily: "var(--font-sans)",
               }}
             >

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -335,12 +335,18 @@ function LoginContent() {
               >
                 Dev — seed users
               </div>
+              <label htmlFor="dev-email" className="sr-only">
+                Email
+              </label>
               <input
+                id="dev-email"
                 type="email"
                 placeholder="persona_a@test.local"
                 value={devEmail}
                 onChange={(e) => setDevEmail(e.target.value)}
                 required
+                autoComplete="email"
+                spellCheck={false}
                 style={{
                   border: "1px solid var(--border-default)",
                   borderRadius: 10,
@@ -352,12 +358,17 @@ function LoginContent() {
                   outline: "none",
                 }}
               />
+              <label htmlFor="dev-password" className="sr-only">
+                Contraseña
+              </label>
               <input
+                id="dev-password"
                 type="password"
                 placeholder="password123"
                 value={devPassword}
                 onChange={(e) => setDevPassword(e.target.value)}
                 required
+                autoComplete="current-password"
                 style={{
                   border: "1px solid var(--border-default)",
                   borderRadius: 10,
@@ -374,7 +385,7 @@ function LoginContent() {
                   role="alert"
                   style={{
                     fontSize: 12,
-                    color: "var(--status-danger)",
+                    color: "var(--status-danger-text)",
                     fontFamily: "var(--font-sans)",
                   }}
                 >

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,17 @@
 @custom-variant dark (&:is(.dark *));
 
 @layer base {
+  /* Tailwind v4 defaults border-color to currentColor; without this, shadcn
+     components using a bare `border` utility inherit the text color as their
+     border (near-white in dark, near-black in light). Pin the default to the
+     DS subtle border token — explicit border-color utilities still win. */
+  *,
+  ::before,
+  ::after,
+  ::backdrop {
+    border-color: var(--border-subtle);
+  }
+
   button,
   [role="button"],
   select,
@@ -128,7 +139,7 @@
   --border-subtle: rgba(0, 0, 0, 0.06);
   --border-default: var(--color-neutral-200);
   --border-strong: var(--color-neutral-300);
-  --border-focus: var(--color-violet-600);
+  --border-focus: var(--color-violet-500);
 
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04);
   --shadow-md: 0 1px 3px rgba(0, 0, 0, 0.08), 0 4px 16px rgba(0, 0, 0, 0.06);
@@ -212,6 +223,7 @@
   --bg-base: var(--color-neutral-900);
   --bg-elevated: var(--color-neutral-800);
   --bg-sunken: rgba(255, 255, 255, 0.05);
+  --bg-overlay: rgba(0, 0, 0, 0.6);
 
   --fg-1: var(--color-neutral-50);
   --fg-2: var(--color-neutral-450); /* #9a9aa6 → 6.88:1 sobre dark bg ✅ */
@@ -268,6 +280,19 @@ select:focus-visible {
 :focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
+}
+
+/* ── REDUCED MOTION ───────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
 /* ── BASE ─────────────────────────────────────────────────── */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { DM_Sans, JetBrains_Mono } from "next/font/google";
+import Script from "next/script";
 import { Providers } from "@/lib/providers";
 import "./globals.css";
 
@@ -67,14 +68,16 @@ export default function RootLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <html lang="es" className={`${dmSans.variable} ${jetbrainsMono.variable}`}>
-      {/* Pre-paint dark mode detection — must run before first paint to avoid FOUC */}
-      <script
-        dangerouslySetInnerHTML={{
-          __html: `(function(){try{if(window.matchMedia('(prefers-color-scheme: dark)').matches){document.documentElement.classList.add('dark')}}catch(e){}})()`,
-        }}
-      />
+    <html
+      lang="es"
+      className={`${dmSans.variable} ${jetbrainsMono.variable}`}
+      suppressHydrationWarning
+    >
       <body>
+        {/* Pre-paint dark mode detection — must run before first paint to avoid FOUC */}
+        <Script id="theme-detect" strategy="beforeInteractive">
+          {`(function(){try{if(window.matchMedia('(prefers-color-scheme: dark)').matches){document.documentElement.classList.add('dark')}}catch(e){}})()`}
+        </Script>
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/src/components/shared/month-summary-card.tsx
+++ b/src/components/shared/month-summary-card.tsx
@@ -74,7 +74,7 @@ export function MonthSummaryCard({
     {
       label: "Ingresos",
       amt: balance.totalIncome,
-      color: "var(--status-success)",
+      color: "var(--status-success-text)",
     },
     {
       label: "Cuotas activas",
@@ -96,8 +96,8 @@ export function MonthSummaryCard({
       amt: balance.savingsCapacity,
       color:
         balance.savingsCapacity >= 0
-          ? "var(--status-success)"
-          : "var(--status-danger)",
+          ? "var(--status-success-text)"
+          : "var(--status-danger-text)",
     },
   ];
   return (

--- a/src/components/shared/responsive-modal.tsx
+++ b/src/components/shared/responsive-modal.tsx
@@ -42,6 +42,7 @@ export function ResponsiveModal({
             background: "var(--bg-elevated)",
             border: "none",
             padding: "20px 20px 0",
+            overscrollBehavior: "contain",
           }}
         >
           <div
@@ -98,6 +99,7 @@ export function ResponsiveModal({
             boxShadow: "0 20px 60px rgba(0,0,0,0.18)",
             padding: "28px 24px 32px",
             maxHeight: "85vh",
+            overscrollBehavior: "contain",
           }}
         >
           <DialogPrimitive.Close

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -20,9 +20,9 @@ const badgeVariants = cva(
         link: "text-primary underline-offset-4 [a&]:hover:underline",
         // ── App variants ──────────────────────────────────────
         success:
-          "[background-color:var(--status-success-subtle)] [color:var(--status-success)]",
+          "[background-color:var(--status-success-subtle)] [color:var(--status-success-text)]",
         danger:
-          "[background-color:var(--status-danger-subtle)] [color:var(--status-danger)]",
+          "[background-color:var(--status-danger-subtle)] [color:var(--status-danger-text)]",
         warning:
           "[background-color:var(--status-warning-subtle)] [color:var(--status-warning-fg)]",
         neutral:

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-[color,background-color,border-color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/src/lib/actions/expenses.ts
+++ b/src/lib/actions/expenses.ts
@@ -40,6 +40,62 @@ export async function upsertIncome(amount: number, month: string) {
   revalidatePath("/settings");
 }
 
+export async function ensureIncomeCarriedForward(
+  coupleId: string,
+  month: string,
+): Promise<{ created: number }> {
+  const { supabase } = await getCouple();
+
+  const { data: members } = await supabase
+    .from("couple_members")
+    .select("user_id")
+    .eq("couple_id", coupleId);
+
+  if (!members?.length) return { created: 0 };
+
+  const { data: existing } = await supabase
+    .from("incomes")
+    .select("user_id")
+    .eq("couple_id", coupleId)
+    .eq("month", month);
+
+  const existingUserIds = new Set(existing?.map((e) => e.user_id));
+  const missingUserIds = members
+    .map((m) => m.user_id)
+    .filter((id) => !existingUserIds.has(id));
+
+  if (!missingUserIds.length) return { created: 0 };
+
+  let created = 0;
+  for (const userId of missingUserIds) {
+    const { data: lastIncome } = await supabase
+      .from("incomes")
+      .select("amount")
+      .eq("couple_id", coupleId)
+      .eq("user_id", userId)
+      .lt("month", month)
+      .order("month", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (lastIncome) {
+      await supabase.from("incomes").insert({
+        couple_id: coupleId,
+        user_id: userId,
+        month,
+        amount: lastIncome.amount,
+      });
+      created++;
+    }
+  }
+
+  if (created > 0) {
+    revalidatePath("/dashboard");
+    revalidatePath("/settings");
+  }
+  return { created };
+}
+
 // ── INSTALLMENT PURCHASES ─────────────────────────────────────
 
 export async function createInstallmentPurchase(data: {
@@ -225,12 +281,57 @@ export async function updateFixedExpenseInstanceAmount(
 
   const { supabase } = await getCouple();
 
+  // Storing the template amount as an override would keep the "editado" badge
+  // showing forever, so re-entering the template amount clears the override instead.
+  let amountOverride = amount;
+  if (amount !== null) {
+    const { data: instance } = await supabase
+      .from("fixed_expense_instances")
+      .select("fixed_expense_templates(amount)")
+      .eq("id", instanceId)
+      .single();
+
+    if (instance?.fixed_expense_templates?.amount === amount) {
+      amountOverride = null;
+    }
+  }
+
   const { error } = await supabase
     .from("fixed_expense_instances")
-    .update({ amount_override: amount })
+    .update({ amount_override: amountOverride })
     .eq("id", instanceId);
 
   if (error) throw new Error("No se pudo actualizar el monto");
+
+  revalidatePath("/expenses");
+  revalidatePath("/dashboard");
+}
+
+export async function updateFixedExpenseInstanceDueDay(
+  instanceId: string,
+  dueDay: number,
+): Promise<void> {
+  if (!Number.isInteger(dueDay) || dueDay < 1 || dueDay > 31) {
+    throw new Error("El día de vencimiento debe estar entre 1 y 31");
+  }
+
+  const { supabase } = await getCouple();
+
+  const { data: instance } = await supabase
+    .from("fixed_expense_instances")
+    .select("fixed_expense_templates(due_day)")
+    .eq("id", instanceId)
+    .single();
+
+  const dueDayOverride =
+    instance?.fixed_expense_templates?.due_day === dueDay ? null : dueDay;
+
+  const { error } = await supabase
+    .from("fixed_expense_instances")
+    .update({ due_day: dueDayOverride })
+    .eq("id", instanceId);
+
+  if (error) throw new Error("No se pudo actualizar el día de vencimiento");
 
   revalidatePath("/expenses");
   revalidatePath("/dashboard");

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -22,6 +22,32 @@ export function getPreviousMonthDate(reference = new Date()): string {
 
 export { getInitials } from "./utils/initials";
 
+const SHORT_MONTHS_ES = [
+  "ene",
+  "feb",
+  "mar",
+  "abr",
+  "may",
+  "jun",
+  "jul",
+  "ago",
+  "sep",
+  "oct",
+  "nov",
+  "dic",
+];
+
+/**
+ * Formats a plain "YYYY-MM-DD" date string as "D mmm" (e.g. "22 abr").
+ * Pure string transform — no Date parsing, so it is deterministic and
+ * hydration-safe regardless of the runtime timezone.
+ */
+export function formatDayMonth(isoDate: string): string {
+  const [, month, day] = isoDate.split("-").map(Number);
+  if (!month || !day || month < 1 || month > 12) return isoDate;
+  return `${day} ${SHORT_MONTHS_ES[month - 1]}`;
+}
+
 export function formatMonth(isoDate: string): string {
   const [year, month] = isoDate.split("-");
   const d = new Date(Number(year), Number(month) - 1);

--- a/src/lib/utils/__tests__/balance.test.ts
+++ b/src/lib/utils/__tests__/balance.test.ts
@@ -135,6 +135,7 @@ describe("calculateMonthlyBalance", () => {
           created_at: "",
           status: "CONFIRMED" as string,
           amount_override: null as number | null,
+          due_day: null as number | null,
           paid_by_user_id: null as string | null,
           fixed_expense_templates: {
             id: "t1",
@@ -157,6 +158,7 @@ describe("calculateMonthlyBalance", () => {
           created_at: "",
           status: "CONFIRMED" as string,
           amount_override: null as number | null,
+          due_day: null as number | null,
           paid_by_user_id: null as string | null,
           fixed_expense_templates: {
             id: "t2",
@@ -396,6 +398,7 @@ describe("calculateMonthlyBalance", () => {
       created_at: "",
       status: "CONFIRMED" as string,
       amount_override: null as number | null,
+      due_day: null as number | null,
       paid_by_user_id: null as string | null,
       fixed_expense_templates: baseTemplate,
     };
@@ -578,6 +581,7 @@ describe("calculateMonthlyBalance — payer attribution (payer-attribution)", ()
       created_at: "",
       status: "CONFIRMED" as string,
       amount_override: null as number | null,
+      due_day: null as number | null,
       fixed_expense_templates: { ...template, amount },
     };
   }
@@ -803,6 +807,7 @@ describe("effectiveFixedAmount", () => {
     created_at: "",
     status: "CONFIRMED" as string,
     amount_override: null as number | null,
+    due_day: null as number | null,
     paid_by_user_id: null as string | null,
     fixed_expense_templates: baseTemplate,
   };
@@ -851,6 +856,7 @@ describe("calculateMonthlyBalance — PENDING_CONFIRMATION status (RF-07)", () =
     created_at: "",
     status: "PENDING_CONFIRMATION" as string,
     amount_override: null as number | null,
+    due_day: null as number | null,
     paid_by_user_id: null as string | null,
     fixed_expense_templates: template,
   };

--- a/src/lib/utils/__tests__/due-dates.test.ts
+++ b/src/lib/utils/__tests__/due-dates.test.ts
@@ -44,6 +44,7 @@ function makeInstance(
     month: "2026-05-01",
     paid: false,
     amount_override: null,
+    due_day: null,
     status: "CONFIRMED",
     paid_by_user_id: null,
     created_at: "2026-05-01T00:00:00Z",

--- a/src/lib/utils/__tests__/utils.test.ts
+++ b/src/lib/utils/__tests__/utils.test.ts
@@ -3,9 +3,30 @@ import {
   formatARS,
   getMonthDate,
   formatMonth,
+  formatDayMonth,
   getPreviousMonthDate,
 } from "@/lib/utils";
 import { getInitials } from "@/lib/utils/initials";
+
+describe("formatDayMonth", () => {
+  it("formatea 'YYYY-MM-DD' como 'D mmm' en español", () => {
+    expect(formatDayMonth("2026-04-22")).toBe("22 abr");
+    expect(formatDayMonth("2026-07-05")).toBe("5 jul");
+    expect(formatDayMonth("2026-01-01")).toBe("1 ene");
+    expect(formatDayMonth("2026-12-31")).toBe("31 dic");
+  });
+
+  it("no aplica desfase por zona horaria (transformación pura de string)", () => {
+    // new Date("2026-01-01") caería a "31 dic" en TZ negativas; el string puro no.
+    expect(formatDayMonth("2026-01-01")).toBe("1 ene");
+  });
+
+  it("devuelve la entrada sin cambios si el mes o el día son inválidos", () => {
+    expect(formatDayMonth("2026-13-01")).toBe("2026-13-01");
+    expect(formatDayMonth("2026-00-10")).toBe("2026-00-10");
+    expect(formatDayMonth("basura")).toBe("basura");
+  });
+});
 
 describe("formatARS", () => {
   it("formatea números enteros con separador de miles (ARS)", () => {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -127,6 +127,7 @@ export type Database = {
           amount_override: number | null;
           couple_id: string;
           created_at: string;
+          due_day: number | null;
           id: string;
           month: string;
           paid: boolean;
@@ -138,6 +139,7 @@ export type Database = {
           amount_override?: number | null;
           couple_id: string;
           created_at?: string;
+          due_day?: number | null;
           id?: string;
           month: string;
           paid?: boolean;
@@ -149,6 +151,7 @@ export type Database = {
           amount_override?: number | null;
           couple_id?: string;
           created_at?: string;
+          due_day?: number | null;
           id?: string;
           month?: string;
           paid?: boolean;

--- a/supabase/migrations/20260709130904_add_due_day_override_to_fixed_expense_instances.sql
+++ b/supabase/migrations/20260709130904_add_due_day_override_to_fixed_expense_instances.sql
@@ -1,0 +1,6 @@
+-- Allow per-month due_day overrides on fixed_expense_instances.
+-- NULL means "inherit the template's due_day" — matches amount_override convention.
+alter table fixed_expense_instances
+  add column due_day int
+    constraint fixed_instance_due_day_check
+      check (due_day between 1 and 31);


### PR DESCRIPTION
## Summary

Design-system fidelity + full light/dark audit pass, implementing the Claude Design corrections and Web Interface Guidelines fixes on top of several UX bugfixes. Changes are interleaved across shared files, so kept as one green commit.

**Bug fixes**
- Fixed-expense amount no longer stays "editado" when re-set to the template value (clears the override on equality)
- Avatar no longer overlaps the amount (auto-width instead of a fixed icon button)
- Per-instance `due_day` override: migration + `updateFixedExpenseInstanceDueDay` + edit UI; "Vence día" reads the instance override
- Replaced undefined `--color-teal`/`--color-coral` vars with real semantic tokens (washed-out colours)
- Income carries forward into a new month automatically (mirrors `ensureFixedExpenseInstances`) — no manual re-entry, no confirmation prompt
- Root-layout hydration: pre-paint theme script via `next/script` `beforeInteractive` + `suppressHydrationWarning` on `<html>`

**Design-system parity**
- Aligned `--border-focus` and dark `--bg-overlay` to the DS tokens
- Added the missing shadcn base `border-color` rule (Tailwind v4 defaults to `currentColor` → near-white card borders in dark, near-black in light)

**Web Interface Guidelines / a11y**
- `prefers-reduced-motion`, `overscroll-behavior` on sheets, `transition-all` → explicit props, ellipsis char, list-item truncation, hydration-safe date i18n, visible focus ring on money inputs, type-specific submit labels, labelled dev-login inputs
- Due-day grid picker replaces the numeric input
- Deep-linked filter/category and month to URL query params
- Dark-mode contrast: danger + success text/border now use the `-text` token step, fixing WCAG AA failures (was ~2.5–4.3, now ≥4.5)

## SDD Traceability

`size:exception` — interactive design/QA pass driven from Claude Design + WIG audit, not run through the SDD workflow. No engram change artifacts.

## QA Gate

- [ ] `sdd-verify` — n/a (not an SDD change)
- [x] New/changed specs — none added; existing `e2e/` suite covers the touched surfaces
- [x] CI checks green locally: **144/144** vitest, **100/100** playwright (incl. axe a11y on all pages), `tsc --noEmit` clean, lint clean on touched files
- [x] UX sign-off on visual/a11y changes — reviewed interactively across light + dark

## Release / Deploy

- [x] Adds a Supabase migration (`supabase/migrations/20260709130904_add_due_day_override_to_fixed_expense_instances.sql`) — nullable `due_day` on `fixed_expense_instances`; applied locally via `supabase migration up` (no reset), applies cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
