### PR TITLE
fix: carry partner income forward and make due-day editable from list

### DIFF
--- a/src/app/(app)/expenses/_components/fijo-item.tsx
+++ b/src/app/(app)/expenses/_components/fijo-item.tsx
@@ -24,11 +24,13 @@ export function FijoItem({
   isLast,
   getPersonInitials,
   getPerson,
+  onEditDueDay,
 }: {
   readonly fi: FixedExpenseInstance;
   readonly isLast: boolean;
   readonly getPersonInitials?: (id: string) => string;
   readonly getPerson?: (id: string) => "a" | "b";
+  readonly onEditDueDay?: (instanceId: string) => void;
 }) {
   const [, startTransition] = useTransition();
   const queryClient = useQueryClient();
@@ -116,16 +118,42 @@ export function FijoItem({
         >
           {fi.fixed_expense_templates.description}
         </div>
-        <div
-          style={{
-            fontSize: 11,
-            color: "var(--fg-3)",
-            marginTop: 1,
-            fontFamily: "var(--font-sans)",
-          }}
-        >
-          Vence día {fi.due_day ?? fi.fixed_expense_templates.due_day}
-        </div>
+        {onEditDueDay ? (
+          <button
+            type="button"
+            onClick={() => onEditDueDay(fi.id)}
+            aria-label="Editar día de vencimiento"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
+              marginTop: 1,
+              padding: 0,
+              border: "none",
+              background: "transparent",
+              cursor: "pointer",
+              fontSize: 11,
+              color: "var(--fg-3)",
+              fontFamily: "var(--font-sans)",
+            }}
+          >
+            Vence día {fi.due_day ?? fi.fixed_expense_templates.due_day}
+            <span aria-hidden="true" style={{ color: "var(--accent)" }}>
+              ✎
+            </span>
+          </button>
+        ) : (
+          <div
+            style={{
+              fontSize: 11,
+              color: "var(--fg-3)",
+              marginTop: 1,
+              fontFamily: "var(--font-sans)",
+            }}
+          >
+            Vence día {fi.due_day ?? fi.fixed_expense_templates.due_day}
+          </div>
+        )}
         {hasOverride && (
           <span
             style={{

--- a/src/app/(app)/expenses/page.tsx
+++ b/src/app/(app)/expenses/page.tsx
@@ -960,6 +960,9 @@ function ExpensesView() {
                           isLast={i === fijos.length - 1}
                           getPersonInitials={getPersonInitials}
                           getPerson={getPerson}
+                          onEditDueDay={(id) =>
+                            setFlow({ step: "edit-service", instanceId: id })
+                          }
                         />
                       </li>
                     ))}

--- a/src/lib/actions/expenses.ts
+++ b/src/lib/actions/expenses.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { createClient } from "@/lib/supabase/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { getMonthDate } from "@/lib/utils";
 import { revalidatePath } from "next/cache";
 
@@ -46,7 +46,12 @@ export async function ensureIncomeCarriedForward(
 ): Promise<{ created: number }> {
   const { supabase } = await getCouple();
 
-  const { data: members } = await supabase
+  // The couple_members SELECT policy is `user_id = auth.uid()`, so the RLS
+  // client only ever sees the current user's own membership row. To carry the
+  // partner's income forward we need the full member list, so read it with the
+  // service client (same pattern as getCoupleMemberProfiles).
+  const service = await createServiceClient();
+  const { data: members } = await service
     .from("couple_members")
     .select("user_id")
     .eq("couple_id", coupleId);


### PR DESCRIPTION
## Contexto

Dos bugs reportados en producción sobre las pantallas de dashboard/gastos.

## Bug 1 — el sueldo del partner no se arrastra

El carry-forward de ingresos (`ensureIncomeCarriedForward`) solo creaba el ingreso del **usuario actual**. En el dashboard aparecía "Deivy · 100% / Annie · 0% / \$0".

**Causa raíz:** la política SELECT de `couple_members` es `user_id = auth.uid()`, así que listar los miembros con el client RLS devuelve **solo la fila del usuario actual**. Corriendo como Deivy, el loop nunca veía a Annie.

**Fix:** leer la lista de miembros con el **service client** (mismo patrón que `getCoupleMemberProfiles`, que usa un RPC SECURITY DEFINER). El insert ya pasaba la RLS (el `with_check` de `incomes` solo exige que `auth.uid()` sea miembro de la pareja).

## Bug 2 — no se podía editar la fecha de vencimiento

La columna `due_day` existe en prod, la RLS permite el update y la server action era correcta — pero ninguna instancia tenía override (todas `null`).

**Causa raíz:** descubribilidad. El `DueDayPicker` vive en `EditServiceSheet`, cuyo único acceso era `FAB (+) → Servicio → lista → elegir`. La fila del servicio no tenía forma de abrirlo.

**Fix:** la línea "Vence día X" de cada servicio ahora es un botón (con ✎) que abre el editor directamente.

## Archivos

- `src/lib/actions/expenses.ts` — service client para leer los miembros de la pareja
- `src/app/(app)/expenses/_components/fijo-item.tsx` — botón editable "Vence día"
- `src/app/(app)/expenses/page.tsx` — cablea el callback `onEditDueDay`

## Verificación

- `tsc --noEmit` limpio
- `eslint` limpio (+ pre-commit hook)
- El bug del sueldo se auto-corrige en la próxima carga del dashboard una vez desplegado (no requiere migración ni backfill)