### PR TITLE
fix+feat(expenses): due-day dashboard sync, lucide icons, and personal services

### DIFF
--- a/.claude/skills/qa-qacito-gate/SKILL.md
+++ b/.claude/skills/qa-qacito-gate/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: qa-qacito-gate
+description: QA Automation Senior playbook for sdd-verify — scopes, fills coverage gaps, and runs Qacito against changed code, then commits the resulting specs so existing CI (GitHub Checks) becomes the persisted evidence. Trigger whenever sdd-verify runs, or when asked to QA-test the current state of the app.
+user-invocable: false
+---
+
+# QA Qacito Gate
+
+Load this skill during `sdd-verify` (or any ad-hoc "QA test the site" request). It defines how the QA Automation Senior role validates a change and where the evidence lives.
+
+## Evidence model — read this first
+
+Evidence is the **existing GitHub Checks**, not a new dashboard or a hand-written PR comment.
+
+- `.github/workflows/ci.yml` already runs `lint`, `unit`, `e2e`, `a11y` as native checks on every PR and uploads `playwright-report` as a CI artifact on failure (`actions/upload-artifact`).
+- Qacito's `generate_report` writes local `.md`/`.html` files to an `outputDir` — it does **not** return a hosted dashboard URL. Treat it as a local artifact, same category as `playwright-report`.
+- Qacito's job is to make sure the **right specs exist and pass** before CI runs them — not to duplicate CI's pass/fail in a separate report or comment.
+
+## Steps
+
+1. **Scope the change**
+   - `get_changed_files(projectPath, base: "master")` — what changed
+   - `get_impacted_specs(projectRoot, changedFiles, specsDir: "e2e")` — which existing Playwright specs already cover it
+
+2. **Fill coverage gaps**
+   - If impacted routes/components have no covering spec, run `analyze_project(projectRoot)` once to generate a test plan + Playwright specs under `qacito_tests/`
+   - Adapt generated specs into `e2e/`, following this project's existing fixtures/conventions (see `e2e/happy-path.spec.ts`, `e2e/pages/*.page.ts`) — CI only runs `e2e/`, not `qacito_tests/`
+
+3. **Run locally for fast feedback**
+   - `run_tests` (or `start_test_run` + `get_run_status` for parallel specs) on the impacted/new specs
+   - `check_accessibility` on changed routes
+   - `dual_evaluate` for visual diffs when UI changed — if the change implements a Claude Design handoff, compare against that bundle's `preview/` references
+   - `generate_report(runId, outputDir: "playwright-report/qacito")` for a local summary used in the verify report
+
+4. **Commit specs — let CI be the record**
+   - If new/updated specs pass locally, commit them to `e2e/`. CI's `e2e`/`a11y` jobs then run them on the PR and produce the team-visible, authoritative pass/fail (GitHub Checks)
+   - Do not mark `sdd-verify` as PASS if specs were generated but not committed — an uncommitted spec produces no evidence
+
+5. **Report**
+   - `sdd/{change}/verify-report` (engram) includes: which specs were added/changed, the local Qacito run summary, and a pointer to "see CI checks on the PR for the authoritative result"
+   - `gh pr comment` is for a short narrative only (e.g. "Added 3 specs covering X; see CI checks for results") — never a hand-built pass/fail table that duplicates the CI check

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- What changed and why -->
+
+## SDD Traceability
+
+<!-- Engram topic keys for sdd/<change>/* — or note "size:exception" with a one-line reason -->
+
+- Proposal: `sdd/<change>/proposal`
+- Spec: `sdd/<change>/spec`
+- Design: `sdd/<change>/design`
+- Tasks: `sdd/<change>/tasks`
+- Verify report: `sdd/<change>/verify-report`
+
+## QA Gate
+
+- [ ] `sdd-verify` ran — see [qa-qacito-gate](.claude/skills/qa-qacito-gate/SKILL.md)
+- [ ] New/changed specs (if any) committed under `e2e/`
+- [ ] CI checks green: lint, unit, e2e, a11y
+- [ ] UX sign-off on visual/a11y changes (if applicable)
+
+## Release / Deploy
+
+<!-- Only relevant if this PR triggers a release-please release -->
+
+- [ ] If this PR adds Supabase migrations, confirm they're included in `supabase/migrations/` and will apply cleanly on release

--- a/e2e/personal-service.spec.ts
+++ b/e2e/personal-service.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * Personal Fixed Expense (servicio propio) E2E
+ *
+ * Verifies the flow added alongside the dashboard due-day fix: a fixed expense
+ * (servicio) can be created as personal — owned by one member and excluded from
+ * the proportional split — mirroring the shared/personal toggle on compras.
+ *
+ * Flow: Servicios tab → Nuevo servicio → toggle "Gasto personal" → pick payer →
+ * save → item shows the "Personal" badge → template persists is_shared=false and
+ * owner_user_id.
+ */
+
+import { test, expect } from "./fixtures";
+import { TEST_EMAIL } from "./config";
+import { createClient } from "@supabase/supabase-js";
+import type { Database } from "../src/types/database";
+
+const TS = Date.now();
+
+async function getTestUserId(
+  adminClient: ReturnType<typeof createClient<Database>>,
+): Promise<string> {
+  const { data: users } = await adminClient.auth.admin.listUsers();
+  const u = users?.users.find((u) => u.email === TEST_EMAIL);
+  if (!u) throw new Error(`Test user ${TEST_EMAIL} not found`);
+  return u.id;
+}
+
+test.describe("Servicio personal: creación, badge y persistencia", () => {
+  const desc = `E2E-servicio-personal-${TS}`;
+  let createdTemplateId: string | null = null;
+
+  test.afterEach(async ({ adminClient }) => {
+    if (createdTemplateId) {
+      await adminClient
+        .from("fixed_expense_instances")
+        .delete()
+        .eq("template_id", createdTemplateId);
+      await adminClient
+        .from("fixed_expense_templates")
+        .delete()
+        .eq("id", createdTemplateId);
+      createdTemplateId = null;
+    }
+  });
+
+  test("crea un servicio propio con dueño y lo marca como Personal", async ({
+    authenticatedPage: page,
+    coupleId,
+    adminClient,
+  }) => {
+    test.slow();
+    const userId = await getTestUserId(adminClient);
+
+    await page.goto("/expenses");
+    await page.getByTestId("tab-servicios").click();
+
+    // Servicios add flow: FAB → type selector → servicio → service list → nuevo
+    await page.getByLabel("Agregar gasto").click();
+    await page.getByTestId("type-option-servicio").click();
+    await page.getByTestId("service-list-sheet").waitFor({ state: "visible" });
+    await page.getByText("+ Nuevo servicio").click();
+    const dialog = page.getByTestId("add-sheet-dialog");
+    await expect(dialog).toBeVisible();
+
+    // Fill the base fields (scoped to the dialog — the list behind it also has
+    // "Monto"-labelled controls)
+    await dialog.getByLabel("Descripción").fill(desc);
+    await dialog.getByLabel("Monto").fill("30000");
+    await dialog.getByTestId("field-due-day").fill("10");
+
+    // Flip to shared → personal. The label reflects the new state immediately.
+    await dialog.getByTestId("toggle-is-shared").click();
+    await expect(dialog.getByText("Gasto personal")).toBeVisible();
+
+    // The payer selector only renders for couples with 2+ members. With a single
+    // member the owner defaults to the current user, so guard on visibility.
+    const payerOption = dialog.getByTestId(`payer-option-${userId}`);
+    if (await payerOption.isVisible()) {
+      await payerOption.click();
+      await expect(payerOption).toHaveAttribute("aria-pressed", "true");
+    }
+
+    await dialog.getByRole("button", { name: "Guardar" }).click();
+
+    await expect(dialog).not.toBeVisible({ timeout: 5_000 });
+
+    // The item shows in the list with the Personal badge
+    const item = page.getByText(desc).first();
+    await expect(item).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("Personal").first()).toBeVisible();
+
+    // Persisted as personal, owned by the payer
+    const { data } = await adminClient
+      .from("fixed_expense_templates")
+      .select("id, is_shared, owner_user_id")
+      .eq("couple_id", coupleId)
+      .eq("description", desc)
+      .single();
+
+    expect(data).not.toBeNull();
+    if (data) {
+      createdTemplateId = data.id;
+      expect(data.is_shared).toBe(false);
+      expect(data.owner_user_id).toBe(userId);
+    }
+  });
+});

--- a/src/app/(app)/expenses/_components/add-sheet.tsx
+++ b/src/app/(app)/expenses/_components/add-sheet.tsx
@@ -277,7 +277,7 @@ export function AddSheet({
       autoRenew,
       requiresMonthlyReview,
       isShared,
-      tab === "cuotas" ? payerId : undefined,
+      tab === "cuotas" || (tab === "fijos" && !isShared) ? payerId : undefined,
     );
   }
 
@@ -423,7 +423,7 @@ export function AddSheet({
           />
         )}
 
-        {tab === "variables" && (
+        {(tab === "variables" || tab === "fijos") && (
           <div
             style={{
               marginBottom: 14,
@@ -477,64 +477,66 @@ export function AddSheet({
           </div>
         )}
 
-        {tab === "cuotas" && members && members.length >= 2 && (
-          <div style={{ marginBottom: 14 }}>
-            <div style={{ ...labelCss, marginBottom: 8 }}>¿Quién paga?</div>
-            <div
-              data-testid="payer-selector"
-              style={{ display: "flex", gap: 8 }}
-            >
-              {members.map((m, idx) => {
-                const person: "a" | "b" = idx === 0 ? "a" : "b";
-                const isSelected = payerId === m.user_id;
-                return (
-                  <button
-                    key={m.user_id}
-                    type="button"
-                    data-testid={`payer-option-${m.user_id}`}
-                    onClick={() => setPayerId(m.user_id)}
-                    aria-pressed={isSelected}
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 8,
-                      flex: 1,
-                      padding: "8px 12px",
-                      borderRadius: 10,
-                      border: isSelected
-                        ? "2px solid var(--accent)"
-                        : "1.5px solid var(--border-default)",
-                      background: isSelected
-                        ? "color-mix(in srgb, var(--accent) 10%, transparent)"
-                        : "var(--bg-sunken)",
-                      cursor: "pointer",
-                      transition: "border 150ms, background 150ms",
-                    }}
-                  >
-                    <PersonAvatar
-                      initials={getInitials(m.full_name)}
-                      person={person}
-                      size="sm"
-                    />
-                    <span
+        {(tab === "cuotas" || (tab === "fijos" && !isShared)) &&
+          members &&
+          members.length >= 2 && (
+            <div style={{ marginBottom: 14 }}>
+              <div style={{ ...labelCss, marginBottom: 8 }}>¿Quién paga?</div>
+              <div
+                data-testid="payer-selector"
+                style={{ display: "flex", gap: 8 }}
+              >
+                {members.map((m, idx) => {
+                  const person: "a" | "b" = idx === 0 ? "a" : "b";
+                  const isSelected = payerId === m.user_id;
+                  return (
+                    <button
+                      key={m.user_id}
+                      type="button"
+                      data-testid={`payer-option-${m.user_id}`}
+                      onClick={() => setPayerId(m.user_id)}
+                      aria-pressed={isSelected}
                       style={{
-                        fontSize: 13,
-                        fontWeight: isSelected ? 600 : 400,
-                        color: isSelected ? "var(--accent)" : "var(--fg-1)",
-                        fontFamily: "var(--font-sans)",
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 8,
+                        flex: 1,
+                        padding: "8px 12px",
+                        borderRadius: 10,
+                        border: isSelected
+                          ? "2px solid var(--accent)"
+                          : "1.5px solid var(--border-default)",
+                        background: isSelected
+                          ? "color-mix(in srgb, var(--accent) 10%, transparent)"
+                          : "var(--bg-sunken)",
+                        cursor: "pointer",
+                        transition: "border 150ms, background 150ms",
                       }}
                     >
-                      {m.full_name.split(" ")[0]}
-                    </span>
-                  </button>
-                );
-              })}
+                      <PersonAvatar
+                        initials={getInitials(m.full_name)}
+                        person={person}
+                        size="sm"
+                      />
+                      <span
+                        style={{
+                          fontSize: 13,
+                          fontWeight: isSelected ? 600 : 400,
+                          color: isSelected ? "var(--accent)" : "var(--fg-1)",
+                          fontFamily: "var(--font-sans)",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {m.full_name.split(" ")[0]}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
         {tab === "cuotas" && (
           <div

--- a/src/app/(app)/expenses/_components/cuota-item.tsx
+++ b/src/app/(app)/expenses/_components/cuota-item.tsx
@@ -2,6 +2,7 @@
 
 import { useTransition } from "react";
 import { useQueryClient } from "@tanstack/react-query";
+import { RefreshCw } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -51,7 +52,17 @@ export function CuotaItem({
             <div style={{ fontSize: 12, color: "var(--fg-3)", marginTop: 2 }}>
               {c.credit_card && <span>{c.credit_card} · </span>}
               Cuota {c.paid_installments} de {c.installments}
-              {c.auto_renew ? <span aria-hidden="true"> 🔄</span> : ""}
+              {c.auto_renew ? (
+                <RefreshCw
+                  aria-label="Se renueva automáticamente"
+                  size={12}
+                  style={{
+                    display: "inline",
+                    verticalAlign: "-2px",
+                    marginLeft: 4,
+                  }}
+                />
+              ) : null}
             </div>
           </div>
           <div className="flex shrink-0 flex-col items-end gap-1">
@@ -122,7 +133,7 @@ export function CuotaItem({
         <div className="mt-2 flex justify-end">
           <DeleteExpenseButton
             title="¿Eliminar cuota?"
-            description={`"${c.description}" se eliminará permanentemente. Esta acción no se puede deshacer.`}
+            description={`"${c.description}" se eliminará. Vas a poder deshacer la acción desde el aviso.`}
             successMessage="Cuota eliminada"
             onConfirm={async () => {
               const row = await deleteInstallmentPurchase(c.id);

--- a/src/app/(app)/expenses/_components/fijo-item.tsx
+++ b/src/app/(app)/expenses/_components/fijo-item.tsx
@@ -157,6 +157,27 @@ export function FijoItem({
             Vence día {fi.due_day ?? fi.fixed_expense_templates.due_day}
           </div>
         )}
+        {!fi.fixed_expense_templates.is_shared && (
+          <span
+            style={{
+              display: "inline-block",
+              marginTop: 3,
+              marginRight: 4,
+              background: "var(--bg-sunken)",
+              color: "var(--fg-3)",
+              border: "1px solid var(--border-subtle)",
+              fontSize: 10,
+              fontWeight: 600,
+              borderRadius: 4,
+              padding: "1px 5px",
+              fontFamily: "var(--font-sans)",
+              textTransform: "uppercase",
+              letterSpacing: "0.05em",
+            }}
+          >
+            Personal
+          </span>
+        )}
         {hasOverride && (
           <span
             style={{

--- a/src/app/(app)/expenses/_components/fijo-item.tsx
+++ b/src/app/(app)/expenses/_components/fijo-item.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from "react";
 import { useQueryClient, useMutation } from "@tanstack/react-query";
+import { Check, Pencil, RotateCcw, X } from "lucide-react";
 import { PersonAvatar } from "@/components/shared/avatar";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -142,9 +143,7 @@ export function FijoItem({
             }}
           >
             Vence día {fi.due_day ?? fi.fixed_expense_templates.due_day}
-            <span aria-hidden="true" style={{ color: "var(--accent)" }}>
-              ✎
-            </span>
+            <Pencil aria-hidden size={12} style={{ color: "var(--accent)" }} />
           </button>
         ) : (
           <div
@@ -244,7 +243,7 @@ export function FijoItem({
                   opacity: amountMutation.isPending ? 0.6 : 1,
                 }}
               >
-                <span aria-hidden="true">✓</span>
+                <Check aria-hidden size={16} />
               </Button>
               <Button
                 variant="ghost"
@@ -261,7 +260,7 @@ export function FijoItem({
                   flexShrink: 0,
                 }}
               >
-                <span aria-hidden="true">×</span>
+                <X aria-hidden size={16} />
               </Button>
             </div>
             {mutationError && (
@@ -310,7 +309,7 @@ export function FijoItem({
                     opacity: amountMutation.isPending ? 0.5 : 1,
                   }}
                 >
-                  <span aria-hidden="true">↻</span>
+                  <RotateCcw aria-hidden size={14} />
                 </Button>
               )}
               <Button

--- a/src/app/(app)/expenses/_components/variable-item.tsx
+++ b/src/app/(app)/expenses/_components/variable-item.tsx
@@ -92,7 +92,7 @@ export function VariableItem({
           </div>
           <DeleteExpenseButton
             title="¿Eliminar compra?"
-            description={`"${v.description}" se eliminará permanentemente. Esta acción no se puede deshacer.`}
+            description={`"${v.description}" se eliminará. Vas a poder deshacer la acción desde el aviso.`}
             successMessage="Compra eliminada"
             onConfirm={async () => {
               const row = await deleteVariableExpense(v.id);

--- a/src/lib/actions/expenses.ts
+++ b/src/lib/actions/expenses.ts
@@ -210,11 +210,24 @@ export async function createFixedExpenseTemplate(data: {
   due_day: number;
   category_id?: string;
   requires_monthly_review?: boolean;
+  is_shared?: boolean;
+  owner_user_id?: string | null;
 }) {
   const { supabase, coupleId } = await getCouple();
+  // A shared template must not carry an owner; a personal one must name it.
+  const isShared = data.is_shared ?? true;
+  const ownerUserId = isShared ? null : (data.owner_user_id ?? null);
+  if (!isShared && !ownerUserId) {
+    throw new Error("Un gasto personal necesita un responsable");
+  }
   const { data: template, error } = await supabase
     .from("fixed_expense_templates")
-    .insert({ ...data, couple_id: coupleId })
+    .insert({
+      ...data,
+      couple_id: coupleId,
+      is_shared: isShared,
+      owner_user_id: ownerUserId,
+    })
     .select("id")
     .single();
   if (!error && template) {

--- a/src/lib/queries/use-expense-save.ts
+++ b/src/lib/queries/use-expense-save.ts
@@ -59,6 +59,8 @@ export function useExpenseSave(tab: Tab) {
             due_day: parsePositiveInt(fields.due_day),
             category_id: categoryId ?? undefined,
             requires_monthly_review: requiresMonthlyReview || undefined,
+            is_shared: isShared,
+            owner_user_id: isShared ? null : payerId,
           });
         } else {
           await createVariableExpense({

--- a/src/lib/utils/__tests__/balance.test.ts
+++ b/src/lib/utils/__tests__/balance.test.ts
@@ -146,6 +146,8 @@ describe("calculateMonthlyBalance", () => {
             due_day: 9,
             active: true,
             requires_monthly_review: false,
+            is_shared: true,
+            owner_user_id: null,
             created_at: "",
           },
         },
@@ -169,6 +171,8 @@ describe("calculateMonthlyBalance", () => {
             due_day: 31,
             active: true,
             requires_monthly_review: false,
+            is_shared: true,
+            owner_user_id: null,
             created_at: "",
           },
         },
@@ -180,6 +184,58 @@ describe("calculateMonthlyBalance", () => {
         variableExpenses: [],
       });
       expect(result.fixedTotal).toBeCloseTo(568_740, 0);
+    });
+
+    it("excluye los gastos fijos personales del split proporcional", () => {
+      const makeFixed = (
+        id: string,
+        amount: number,
+        isShared: boolean,
+        owner: string | null,
+      ) => ({
+        id,
+        template_id: id,
+        couple_id: "c1",
+        month: "2026-04-01",
+        paid: false,
+        created_at: "",
+        status: "CONFIRMED" as string,
+        amount_override: null as number | null,
+        due_day: null as number | null,
+        paid_by_user_id: null as string | null,
+        fixed_expense_templates: {
+          id,
+          couple_id: "c1",
+          category_id: null,
+          description: id,
+          amount,
+          due_day: 10,
+          active: true,
+          requires_monthly_review: false,
+          is_shared: isShared,
+          owner_user_id: owner,
+          created_at: "",
+        },
+      });
+
+      const result = calculateMonthlyBalance({
+        incomes: baseIncomes,
+        installmentPurchases: [],
+        fixedExpenseInstances: [
+          makeFixed("shared", 100_000, true, null),
+          makeFixed("personal", 50_000, false, DEIVY_ID),
+        ],
+        variableExpenses: [],
+      });
+
+      // Total money out includes the personal expense…
+      expect(result.fixedTotal).toBeCloseTo(150_000, 0);
+      expect(result.fixedSharedTotal).toBeCloseTo(100_000, 0);
+      expect(result.fixedIndividualTotal).toBeCloseTo(50_000, 0);
+      // …but only the shared portion enters the proportional split.
+      expect(result.sharedExpensesTotal).toBeCloseTo(100_000, 0);
+      const deivy = result.balances.find((b) => b.userId === DEIVY_ID)!;
+      expect(deivy.obligation).toBeCloseTo(0.6459 * 100_000, -1);
     });
   });
 
@@ -387,6 +443,8 @@ describe("calculateMonthlyBalance", () => {
       due_day: 15,
       active: true,
       requires_monthly_review: false,
+      is_shared: true,
+      owner_user_id: null,
       created_at: "",
     };
     const baseInstance = {
@@ -562,6 +620,8 @@ describe("calculateMonthlyBalance — payer attribution (payer-attribution)", ()
     due_day: 15,
     active: true,
     requires_monthly_review: false,
+    is_shared: true,
+    owner_user_id: null,
     created_at: "",
   };
 
@@ -796,6 +856,8 @@ describe("effectiveFixedAmount", () => {
     due_day: 10,
     active: true,
     requires_monthly_review: false,
+    is_shared: true,
+    owner_user_id: null,
     created_at: "",
   };
   const baseInstance = {
@@ -844,6 +906,8 @@ describe("calculateMonthlyBalance — PENDING_CONFIRMATION status (RF-07)", () =
     due_day: 15,
     active: true,
     requires_monthly_review: true,
+    is_shared: true,
+    owner_user_id: null,
     created_at: "",
   };
 

--- a/src/lib/utils/__tests__/due-dates.test.ts
+++ b/src/lib/utils/__tests__/due-dates.test.ts
@@ -25,6 +25,8 @@ function makeTemplate(
     active: true,
     category_id: null,
     requires_monthly_review: false,
+    is_shared: true,
+    owner_user_id: null,
     created_at: "2026-01-01T00:00:00Z",
     ...overrides,
   };
@@ -151,6 +153,18 @@ describe("getUpcomingDues", () => {
     expect(result.overdue[0].status).toBe("overdue");
     expect(result.today).toHaveLength(0);
     expect(result.upcoming).toHaveLength(0);
+  });
+
+  it("override de instancia gana sobre el due_day del template", () => {
+    // template vence día 10 (overdue), pero la instancia lo overridea a 15 (hoy)
+    const instance = makeInstance({
+      due_day: 15,
+      fixed_expense_templates: { due_day: 10 },
+    });
+    const result = getUpcomingDues([instance], TODAY);
+    expect(result.today).toHaveLength(1);
+    expect(result.today[0].dueDay).toBe(15);
+    expect(result.overdue).toHaveLength(0);
   });
 
   it("borde superior: due_day = today + 8 (fuera de ventana) → excluido", () => {

--- a/src/lib/utils/balance.ts
+++ b/src/lib/utils/balance.ts
@@ -32,6 +32,8 @@ export interface MonthlyBalance {
   savingsCapacity: number;
   installmentTotal: number;
   fixedTotal: number;
+  fixedSharedTotal: number;
+  fixedIndividualTotal: number;
   variableTotal: number;
   variableSharedTotal: number;
   variableIndividualTotal: number;
@@ -59,6 +61,9 @@ export function calculateMonthlyBalance(params: {
   const isSharedExpense = (expense: VariableExpense): boolean =>
     expense.is_shared ?? true;
 
+  const isSharedFixed = (instance: FixedExpenseInstance): boolean =>
+    instance.fixed_expense_templates.is_shared ?? true;
+
   // Monthly installment cost = round(total_amount / installments) per purchase
   // Rounding per-purchase avoids accumulated floating point drift
   // auto_renew purchases are always active regardless of paid_installments
@@ -69,11 +74,19 @@ export function calculateMonthlyBalance(params: {
       0,
     );
 
-  // Fixed expenses: sum effective amounts (override ?? template) for this month
+  // Fixed expenses: sum effective amounts (override ?? template) for this month.
+  // Only shared fixed expenses enter the proportional split; personal ones
+  // belong to their owner and stay out of the settlement (like personal variables).
   const fixedTotal = fixedExpenseInstances.reduce(
     (sum, i) => sum + effectiveFixedAmount(i),
     0,
   );
+
+  const fixedSharedTotal = fixedExpenseInstances
+    .filter(isSharedFixed)
+    .reduce((sum, i) => sum + effectiveFixedAmount(i), 0);
+
+  const fixedIndividualTotal = fixedTotal - fixedSharedTotal;
 
   const variableTotal = variableExpenses.reduce(
     (sum, v) => sum + Number(v.amount),
@@ -88,7 +101,7 @@ export function calculateMonthlyBalance(params: {
 
   const totalExpenses = installmentTotal + fixedTotal + variableTotal;
   const sharedExpensesTotal =
-    installmentTotal + fixedTotal + variableSharedTotal;
+    installmentTotal + fixedSharedTotal + variableSharedTotal;
   const savingsCapacity = totalIncome - totalExpenses;
 
   const balances: PersonBalance[] = incomes.map((income) => {
@@ -100,7 +113,10 @@ export function calculateMonthlyBalance(params: {
       .reduce((sum, v) => sum + Number(v.amount), 0);
 
     const actualPaidFixed = fixedExpenseInstances
-      .filter((fi) => fi.paid && fi.paid_by_user_id === income.user_id)
+      .filter(
+        (fi) =>
+          fi.paid && fi.paid_by_user_id === income.user_id && isSharedFixed(fi),
+      )
       .reduce((sum, fi) => sum + effectiveFixedAmount(fi), 0);
 
     const actualPaidInstallments = installmentPurchases
@@ -114,7 +130,8 @@ export function calculateMonthlyBalance(params: {
         0,
       );
 
-    const actualPaid = actualPaidVariable + actualPaidFixed + actualPaidInstallments;
+    const actualPaid =
+      actualPaidVariable + actualPaidFixed + actualPaidInstallments;
     const netBalance = actualPaid - obligation;
 
     return {
@@ -139,6 +156,8 @@ export function calculateMonthlyBalance(params: {
     savingsCapacity,
     installmentTotal,
     fixedTotal,
+    fixedSharedTotal,
+    fixedIndividualTotal,
     variableTotal,
     variableSharedTotal,
     variableIndividualTotal,

--- a/src/lib/utils/due-dates.ts
+++ b/src/lib/utils/due-dates.ts
@@ -58,7 +58,8 @@ export function getUpcomingDues(
   for (const instance of instances) {
     if (instance.paid) continue;
 
-    const rawDueDay = instance.fixed_expense_templates.due_day;
+    const rawDueDay =
+      instance.due_day ?? instance.fixed_expense_templates.due_day;
     const dueDay = Math.min(rawDueDay, lastDay);
     const daysUntilDue = dueDay - todayDay;
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -186,6 +186,8 @@ export type Database = {
           description: string;
           due_day: number;
           id: string;
+          is_shared: boolean;
+          owner_user_id: string | null;
           requires_monthly_review: boolean;
         };
         Insert: {
@@ -197,6 +199,8 @@ export type Database = {
           description: string;
           due_day: number;
           id?: string;
+          is_shared?: boolean;
+          owner_user_id?: string | null;
           requires_monthly_review?: boolean;
         };
         Update: {
@@ -208,6 +212,8 @@ export type Database = {
           description?: string;
           due_day?: number;
           id?: string;
+          is_shared?: boolean;
+          owner_user_id?: string | null;
           requires_monthly_review?: boolean;
         };
         Relationships: [

--- a/supabase/migrations/20260713093700_add_is_shared_to_fixed_expense_templates.sql
+++ b/supabase/migrations/20260713093700_add_is_shared_to_fixed_expense_templates.sql
@@ -1,0 +1,15 @@
+-- Allow fixed expense templates to be personal (owned by one member) instead of
+-- shared. Mirrors the is_shared concept already present on variable_expenses.
+--   is_shared = true  -> enters the proportional split (default, current behavior)
+--   is_shared = false -> personal to owner_user_id, excluded from the split
+alter table fixed_expense_templates
+  add column is_shared boolean not null default true,
+  add column owner_user_id uuid references auth.users(id) on delete set null;
+
+-- A personal template must name its owner; a shared one must not.
+alter table fixed_expense_templates
+  add constraint fixed_template_owner_check
+    check (
+      (is_shared and owner_user_id is null)
+      or (not is_shared and owner_user_id is not null)
+    );


### PR DESCRIPTION
## Resumen

Tres cambios en la sección de gastos, agrupados por commit:

1. **`fix(expenses)`** — reemplaza glyphs de texto (`✎ ✓ × ↻ 🔄`) por íconos lucide, restos de la migración de íconos del DS; da `aria-label` al indicador de auto-renovación (antes `aria-hidden`); corrige la copy de borrado que decía "no se puede deshacer" mientras el toast ofrece "Deshacer".
2. **`fix(dashboard)`** — el widget de próximos vencimientos leía el `due_day` del template e ignoraba el override por instancia, mostrando un día distinto al de la lista de gastos. Ahora usa `instance.due_day ?? template.due_day`.
3. **`feat(expenses)`** — los servicios (gastos fijos) pueden marcarse como **personales** (de un solo miembro) en vez de siempre compartidos, igual que el toggle de compras.

## Detalle de la feature

- **Migración**: `is_shared` + `owner_user_id` en `fixed_expense_templates`, con CHECK de coherencia (compartido → sin dueño; personal → con dueño) y FK `ON DELETE SET NULL`.
- **Balance** (`balance.ts`): solo los servicios compartidos entran al split proporcional; se agregan `fixedSharedTotal`/`fixedIndividualTotal` en `MonthlyBalance` (simétrico con variables).
- **Formulario** (`add-sheet.tsx`): toggle compartido/personal y selector "¿quién paga?" (reutiliza el de cuotas) para servicios personales.
- **Persistencia**: `createFixedExpenseTemplate` guarda `is_shared`/`owner_user_id`.
- **UI**: badge "Personal" en la lista de servicios.

## Verificación

- **Unit**: 145/145 (incluye tests nuevos de override de due-day y de exclusión de servicios personales del split).
- **e2e**: nuevo `personal-service.spec.ts` — alta → toggle personal → guardar → badge "Personal" → DB `is_shared=false` + `owner_user_id`. Payer-attribution 13/13.
- **DB**: migración aplicada en local sin pérdida de datos; CHECK constraint verificada (acepta personal válido, rechaza personal-sin-dueño y compartido-con-dueño).

## Notas

- La migración corre contra la base remota en el deploy.
- Los tipos de `database.ts` se regeneraron con `supabase gen types` (coinciden exactamente con la edición manual).
