### PR TITLE
ci: validate PR title as Conventional Commits

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,48 @@
+name: PR Title
+
+# PRs are squash-merged with the PR title as the commit subject
+# (squash_merge_commit_title = COMMIT_OR_PR_TITLE). That subject is what
+# release-please parses to decide the next version, so an invalid type
+# (e.g. "fix+feat: ...") silently skips the release. This check enforces a
+# single valid Conventional Commits type on the PR title, matching the repo's
+# commitlint config (@commitlint/config-conventional).
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate title
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Keep in sync with commitlint.config.js (@commitlint/config-conventional)
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+          requireScope: false
+          # commitlint disables subject-case; don't enforce it on the title either
+          subjectPattern: .+
+          # Comment on the PR when the title is invalid, and remove it once fixed
+          wip: false


### PR DESCRIPTION
Adds a lightweight CI check that validates every PR title against Conventional Commits, using the same allowed types as the repo's commitlint config.

## Why

PRs squash-merge with the **PR title** as the commit subject (`squash_merge_commit_title = COMMIT_OR_PR_TITLE`). release-please parses that subject to decide the next version. An invalid type silently skips the release — exactly what happened with the `fix+feat(expenses)` title on #143, which required a manual release recovery (#144).

## What

- New workflow `.github/workflows/pr-title.yml` using `amannn/action-semantic-pull-request`.
- Allowed types kept in sync with `@commitlint/config-conventional`: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test.
- Re-runs on title edits; comments on the PR when the title is invalid.

## Follow-up (optional)

Make **PR Title** a required status check in branch protection so an invalid title actually blocks merge.