### PR TITLE
docs(agents): require destructive migrations to self-backup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,18 @@ Next.js 16 (App Router) · React 19 · TypeScript · Supabase · TanStack Query 
 - NEVER bypass RLS by using the service role key in client-facing code.
 - NEVER create a `route.ts` in the same folder as a `page.tsx` — they conflict. API routes go under `src/app/api/`.
 
-## 11. Next.js framework rules
+## 11. Database migrations
+
+- `.github/workflows/release-please.yml` runs `supabase db push` against **production** automatically whenever a release is created. A migration merged to `master` reaches prod unattended — there is no window to intervene and nobody is prompted.
+- Therefore a header comment like "take a snapshot before applying this" is **not** a safeguard. It is documentation, and it cannot stop the pipeline. Never rely on one.
+- Any migration that DELETEs or DROPs data MUST be recoverable **by construction**: copy every affected row into a backup table inside the same transaction, and document the restore statement in the migration header.
+- Backup tables go in a `backup` schema. `supabase/config.toml` exposes only `public` and `graphql_public`, so a `backup` schema stays off the PostgREST API; also `revoke all ... from anon, authenticated` as defense-in-depth.
+- Write restore statements with **explicit column names on both sides** of the INSERT. Physical column order is not the logical order — `fixed_expense_instances` is `id, template_id, couple_id, month, paid, created_at, amount_override, status, paid_by_user_id, due_day` — so a positional INSERT fails or, worse, silently writes to the wrong columns. (`create table backup.x (like public.y)` does preserve source order, so `insert into backup.x select y.*, now()` is safe.)
+- Verify a destructive migration against a local database **before** merging: seed rows that MUST be deleted alongside rows that MUST survive, run the migration SQL, assert both sets, exercise the restore round-trip, then `ROLLBACK`.
+- NEVER edit a migration that has already been applied — Supabase records it by version and will not re-run it, so the file silently diverges from the real schema history. Fix it forward with a new migration.
+- Use `supabase migration up` to apply locally — NEVER `supabase db reset` (destroys local data).
+
+## 12. Next.js framework rules
 
 Before writing any Next.js code, load the `next-best-practices` skill. It covers:
 


### PR DESCRIPTION
## Summary

Documents the rule that #146 got wrong, so the next destructive migration cannot repeat it.

**What happened.** `20260713233000_cleanup_phantom_fixed_expense_instances.sql` shipped in #146 carrying this header:

> `IRREVERSIBLE: this is a DELETE with no down-migration. Do not run against production without a fresh backup/snapshot`

That instruction was unenforceable. `release-please.yml` runs `supabase db push` against production automatically whenever a release is created, so merging #146 → release v1.20.0 applied the DELETE to prod unattended, with no snapshot and nobody prompted. The comment was documentation dressed up as a safeguard.

**The outcome was fine — the process wasn't.** The predicate was verified after the fact against a local database: it only removes rows that are unpaid, have no `due_day`, no `amount_override`, and belong to months before their template existed. Seeded fixtures confirmed 4 survivors / 0 false deletions across the paid, due-day, amount-override and post-creation cases, so no user data was lost. But nothing guaranteed that at merge time. It went well; it did not go safely.

**This PR** writes the lesson into `AGENTS.md` as section 11 (Next.js rules shift to 12; no section numbers are referenced anywhere, so nothing breaks):

- The pipeline auto-applies migrations to prod — a "snapshot first" comment is never a safeguard.
- Destructive migrations must be recoverable **by construction**: copy affected rows into a `backup` schema table in the same transaction, and document the restore.
- The `backup` schema stays off the PostgREST API (`config.toml` exposes only `public` + `graphql_public`) plus `revoke` from `anon`/`authenticated`.
- Restore statements must name columns on **both** sides — physical column order is not the logical order (`fixed_expense_instances` is `id, template_id, couple_id, month, paid, created_at, amount_override, status, paid_by_user_id, due_day`), so positional INSERTs fail or silently mismatch. This one bit us for real while testing the restore.
- Verify destructive migrations locally first (seed must-delete + must-survive rows, assert, round-trip the restore, `ROLLBACK`).
- Never edit an already-applied migration — fix forward.

**Deliberately not included:** no change to the already-applied cleanup migration. Editing it would only desync the file from Supabase's recorded history without re-running anything. It stays exactly as applied.

## SDD Traceability

Docs-only follow-up to the `expenses-cards-and-ux-fixes` change (#146). Policy persisted in Engram under `db/destructive-migration-policy`. `size:exception` — single-file documentation change, no spec/design cycle.

## QA Gate

- [x] Docs-only; no runtime surface to test
- [x] Prettier clean; no section-number references broken by the renumber
- [ ] CI checks green: lint, unit, e2e, a11y

## Release / Deploy

- [x] No migrations, no schema change, no release impact (`docs:` does not trigger a release-please version bump)
