### PR TITLE
fix(dashboard): exclude sin-factura services from the dues widget

### DIFF
--- a/src/lib/utils/__tests__/due-dates.test.ts
+++ b/src/lib/utils/__tests__/due-dates.test.ts
@@ -157,6 +157,33 @@ describe("getUpcomingDues", () => {
     expect(result.upcoming).toHaveLength(0);
   });
 
+  it("una instancia AWAITING_BILL (sin factura) con due_day pasado NO aparece como vencida", () => {
+    // Reproduce del bug de prod: EPEC 'sin factura', vence día 10, hoy es 15.
+    // Sin la guarda caería en overdue con $0 y con botón Pagar. Debe quedar
+    // fuera de las tres listas — se muestra en /expenses como 'sin factura'.
+    const awaitingOverdue = makeInstance({
+      status: "AWAITING_BILL",
+      amount_override: null,
+      fixed_expense_templates: { due_day: 10, awaits_bill: true },
+    });
+    const result = getUpcomingDues([awaitingOverdue], TODAY);
+    expect(result.overdue).toHaveLength(0);
+    expect(result.today).toHaveLength(0);
+    expect(result.upcoming).toHaveLength(0);
+  });
+
+  it("una instancia legacy PENDING_CONFIRMATION (con monto) SÍ sigue apareciendo", () => {
+    // isBilled excluye solo AWAITING_BILL: las zombie PENDING_CONFIRMATION
+    // tienen monto y deben seguir dunneándose como cualquier fila confirmada.
+    const zombieOverdue = makeInstance({
+      status: "PENDING_CONFIRMATION",
+      fixed_expense_templates: { due_day: 10 },
+    });
+    const result = getUpcomingDues([zombieOverdue], TODAY);
+    expect(result.overdue).toHaveLength(1);
+    expect(result.overdue[0].instance.id).toBe("inst-1");
+  });
+
   it("override de instancia gana sobre el due_day del template", () => {
     // template vence día 10 (overdue), pero la instancia lo overridea a 15 (hoy)
     const instance = makeInstance({

--- a/src/lib/utils/due-dates.ts
+++ b/src/lib/utils/due-dates.ts
@@ -1,4 +1,5 @@
 import type { Database } from "@/types/database";
+import { isBilled } from "./balance";
 
 type FixedExpenseInstanceRow =
   Database["public"]["Tables"]["fixed_expense_instances"]["Row"];
@@ -68,6 +69,13 @@ export function getUpcomingDues(
 
   for (const instance of instances) {
     if (instance.paid) continue;
+    // "sin factura" (AWAITING_BILL) instances have no bill yet: no amount and
+    // nothing to pay, so they can never be "due" or "overdue" — showing one as
+    // "vencido" (and offering a Pagar button that would mark a non-existent
+    // bill paid) is the bug this guards. They surface in /expenses' sin-factura
+    // row instead. Keyed off isBilled (status !== AWAITING_BILL) so legacy
+    // PENDING_CONFIRMATION rows, which DO carry an amount, still appear here.
+    if (!isBilled(instance)) continue;
 
     const rawDueDay =
       instance.due_day ?? instance.fixed_expense_templates.due_day;


### PR DESCRIPTION
## Summary

Bug in production (reported by @dpaul20): a service marked **"sin factura"** (`AWAITING_BILL`) shows up in the dashboard's dues widget under **"⚠️ Vencidos"** once its due day passes — e.g. EPEC, vence día 10, today is the 17th.

Root cause: `getUpcomingDues` classified instances into today/upcoming/overdue purely by `due_day` vs today, filtering only `paid = true`. It never accounted for `AWAITING_BILL`. Two problems:
1. A sin-factura service has **no bill yet** — it can't be "vencido".
2. Its "Pagar" button called `toggleFixedExpenseInstance(id, true)`, which would mark a **non-existent bill** as paid ($0).

Fix: skip `AWAITING_BILL` instances in `getUpcomingDues`, keyed off `isBilled` (`status !== "AWAITING_BILL"`) — the same predicate used across the settlements feature — so legacy `PENDING_CONFIRMATION` rows, which **do** carry an amount, keep appearing. Sin-factura services already have their dedicated row in `/expenses`.

## SDD Traceability

`size:exception` — one-line prod bugfix on the shipped `settlements-and-pending-bills` feature; no new SDD change. Follow-up to `sdd/settlements-and-pending-bills/*`.

## QA Gate

- [x] Unit tests added: AWAITING_BILL with a past due_day is NOT in any bucket; a PENDING_CONFIRMATION (zombie, has amount) still appears. Full suite **250 green** (+2), `tsc --noEmit`, lint.
- [x] Pure-util change — covered by Vitest (`src/lib/utils/__tests__/due-dates.test.ts`)
- [ ] CI: lint, unit, e2e, a11y, typecheck — will run on this PR

## Release / Deploy

- [x] **No migrations.** Merge triggers a code-only release; nothing touches the database.
