### PR TITLE
fix(dashboard): surface reversed debt when a settlement overpays

### DIFF
--- a/src/app/(app)/dashboard/_components/balance-card.tsx
+++ b/src/app/(app)/dashboard/_components/balance-card.tsx
@@ -137,20 +137,20 @@ export function BalanceCard({
   );
   const myPct = Math.round((myBalance?.percentage ?? 0.5) * 100);
 
-  // Headline keys off the settlement-aware remaining debt, not the raw
-  // expense debt — a fully-paid month reads $0 even though expenses created a
-  // debt (design D3: settlements pay down, never rewrite, the balance).
-  const remainingDebt = summary.remainingDebt;
-  const hasDebt = remainingDebt > 0;
+  // Headline keys off the settlement-aware NET position, not the raw expense
+  // debt — a fully-paid month reads $0 even though expenses created a debt,
+  // and an OVERpaid month flips direction ("le debe" swaps) instead of hiding
+  // the reversed debt behind $0 (design D3: settlements pay down, never
+  // rewrite, the balance; `net` carries the flip — see settlement.ts).
+  const net = summary.net;
+  // Guard on the ROUNDED amount so a sub-peso residue (which formatARS would
+  // render as "$0") reads as settled, not as a "$0 le debe" artifact.
+  const hasDebt = net !== null && Math.round(net.amount) > 0;
   const isSettled = !hasDebt && summary.entries.length > 0;
   const debtorName =
-    summary.direction?.debtor === myProfile?.user_id
-      ? myFirstName
-      : partnerFirstName;
+    net?.debtor === myProfile?.user_id ? myFirstName : partnerFirstName;
   const creditorName =
-    summary.direction?.creditor === myProfile?.user_id
-      ? myFirstName
-      : partnerFirstName;
+    net?.creditor === myProfile?.user_id ? myFirstName : partnerFirstName;
   const awaitingNote =
     awaitingBillCount === 1
       ? "Falta 1 factura. Cuando llegue puede aparecer una diferencia."
@@ -174,7 +174,7 @@ export function BalanceCard({
               data-testid="balance-debt-amount"
               className="ds-amount text-[38px] leading-[1.1] font-bold [letter-spacing:-0.02em] [color:var(--status-danger-text)]"
             >
-              {formatARS(remainingDebt)}
+              {formatARS(net?.amount ?? 0)}
             </div>
             <div className="mt-[5px] [font-family:var(--font-sans)] text-[14px] [color:var(--fg-2)]">
               {debtorName} le debe a {creditorName}

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -380,7 +380,7 @@ function DashboardView() {
 
       {coupleId &&
         settlementSummary &&
-        (editingSettlement || (settleOpen && settlementSummary.direction)) && (
+        (editingSettlement || (settleOpen && settlementSummary.net)) && (
           <SettleSheet
             coupleId={coupleId}
             month={month}
@@ -390,9 +390,9 @@ function DashboardView() {
                 full_name: string;
               }[]
             }
-            defaultFromUserId={settlementSummary.direction?.debtor ?? ""}
-            defaultToUserId={settlementSummary.direction?.creditor ?? ""}
-            defaultAmount={settlementSummary.remainingDebt}
+            defaultFromUserId={settlementSummary.net?.debtor ?? ""}
+            defaultToUserId={settlementSummary.net?.creditor ?? ""}
+            defaultAmount={settlementSummary.net?.amount ?? 0}
             editing={editingSettlement ?? undefined}
             onClose={() => {
               setSettleOpen(false);

--- a/src/lib/utils/__tests__/settlement.test.ts
+++ b/src/lib/utils/__tests__/settlement.test.ts
@@ -24,6 +24,7 @@ describe("summarizeSettlements", () => {
       direction: null,
       settledTotal: 0,
       remainingDebt: 0,
+      net: null,
       entries: [],
     });
   });
@@ -98,6 +99,73 @@ describe("summarizeSettlements", () => {
       settlements,
     });
     expect(result.remainingDebt).toBe(-10_051);
+  });
+
+  // ── net (the settlement-aware, direction-flipping position) ───────────────
+
+  it("net mirrors direction when the debtor still owes (remainingDebt > 0)", () => {
+    const result = summarizeSettlements({
+      debtor: ANNIE_ID,
+      creditor: DEIVY_ID,
+      debtAmount: 59_949,
+      settlements: [
+        { from_user_id: ANNIE_ID, to_user_id: DEIVY_ID, amount: 20_000 },
+      ],
+    });
+    // still Annie -> Deivy, for the amount that remains
+    expect(result.net).toEqual({
+      debtor: ANNIE_ID,
+      creditor: DEIVY_ID,
+      amount: 39_949,
+    });
+  });
+
+  it("net FLIPS direction on overpayment: the creditor now owes the surplus (the prod bug)", () => {
+    // Annie owed 195_083 and paid 197_160 — she overpaid, so now DEIVY owes
+    // HER the difference. `direction` stays Annie -> Deivy (the expense side),
+    // but `net` reverses to Deivy -> Annie.
+    const result = summarizeSettlements({
+      debtor: ANNIE_ID,
+      creditor: DEIVY_ID,
+      debtAmount: 195_083,
+      settlements: [
+        { from_user_id: ANNIE_ID, to_user_id: DEIVY_ID, amount: 197_160 },
+      ],
+    });
+    expect(result.remainingDebt).toBe(-2_077);
+    expect(result.direction).toEqual({ debtor: ANNIE_ID, creditor: DEIVY_ID });
+    expect(result.net).toEqual({
+      debtor: DEIVY_ID,
+      creditor: ANNIE_ID,
+      amount: 2_077,
+    });
+  });
+
+  it("net is null when the debt is settled exactly (remainingDebt === 0)", () => {
+    const result = summarizeSettlements({
+      debtor: ANNIE_ID,
+      creditor: DEIVY_ID,
+      debtAmount: 59_949,
+      settlements: [
+        { from_user_id: ANNIE_ID, to_user_id: DEIVY_ID, amount: 59_949 },
+      ],
+    });
+    expect(result.remainingDebt).toBe(0);
+    expect(result.net).toBeNull();
+  });
+
+  it("net carries the full debt when a debtor exists and no settlements were recorded", () => {
+    const result = summarizeSettlements({
+      debtor: ANNIE_ID,
+      creditor: DEIVY_ID,
+      debtAmount: 59_949,
+      settlements: [],
+    });
+    expect(result.net).toEqual({
+      debtor: ANNIE_ID,
+      creditor: DEIVY_ID,
+      amount: 59_949,
+    });
   });
 
   it("no debtor (balanced month) + a settlement recorded anyway: direction comes from the FIRST entry, remainingDebt goes negative by that amount", () => {

--- a/src/lib/utils/settlement.ts
+++ b/src/lib/utils/settlement.ts
@@ -33,9 +33,44 @@ export interface SettlementSummary {
   /** `debtAmount - settledTotal`. Never clamped to zero — see spec
    * "Remaining Debt May Go Negative". */
   remainingDebt: number;
+  /** The CURRENT net position after settlements, as a POSITIVE amount owed in
+   * a direction that FLIPS when an overpayment reverses the roles
+   * (`remainingDebt < 0` — e.g. the debtor paid, then a later shared expense
+   * tipped the balance the other way). `null` when nothing is owed either way
+   * (`remainingDebt === 0`, or no debtor and no settlements). Distinct from
+   * `direction`, which pins to the ORIGINAL expense-debt side and never flips:
+   * `net` is the "X le debe a Y" the UI renders, reversals included. */
+  net: { debtor: string; creditor: string; amount: number } | null;
   /** Every settlement passed in, unmodified — the ledger renders each
    * entry, never a net (design D3 / mockup contract). */
   entries: Settlement[];
+}
+
+/**
+ * Turns a signed remaining debt into a positive amount + the direction it is
+ * owed in. A negative remaining means the base debtor overpaid, so the roles
+ * swap. Zero means settled — nobody owes.
+ */
+function deriveNet(
+  baseDebtor: string,
+  baseCreditor: string,
+  remainingDebt: number,
+): SettlementSummary["net"] {
+  if (remainingDebt > 0) {
+    return {
+      debtor: baseDebtor,
+      creditor: baseCreditor,
+      amount: remainingDebt,
+    };
+  }
+  if (remainingDebt < 0) {
+    return {
+      debtor: baseCreditor,
+      creditor: baseDebtor,
+      amount: -remainingDebt,
+    };
+  }
+  return null;
 }
 
 /**
@@ -57,10 +92,13 @@ export function summarizeSettlements(params: {
   const { debtor, creditor, debtAmount, settlements } = params;
 
   if (settlements.length === 0) {
+    const remainingDebt = debtor ? debtAmount : 0;
     return {
       direction: debtor && creditor ? { debtor, creditor } : null,
       settledTotal: 0,
-      remainingDebt: debtor ? debtAmount : 0,
+      remainingDebt,
+      net:
+        debtor && creditor ? deriveNet(debtor, creditor, remainingDebt) : null,
       entries: [],
     };
   }
@@ -92,10 +130,13 @@ export function summarizeSettlements(params: {
     return sum + Number(s.amount);
   }, 0);
 
+  const remainingDebt = debtAmount - settledTotal;
+
   return {
     direction: { debtor: resolvedDebtor, creditor: resolvedCreditor },
     settledTotal,
-    remainingDebt: debtAmount - settledTotal,
+    remainingDebt,
+    net: deriveNet(resolvedDebtor, resolvedCreditor, remainingDebt),
     entries: settlements,
   };
 }


### PR DESCRIPTION
## Qué

Cuando un pago (settlement) supera la deuda del mes, `remainingDebt` se vuelve negativo, pero la tarjeta de balance lo pisaba a **"$0 / Saldado"** y nunca invertía deudor/acreedor — ocultando una deuda real que ahora corre en sentido contrario.

## Por qué

Caso real de producción (julio 2026): Anita debía ~$195.083 y pagó $197.160 (registró el pago el 17/07). El 23/07 se cargaron gastos compartidos nuevos (Pollo, Sandwichs) que dieron vuelta el balance ~$2.077 a favor de Anita. La app mostraba **$0** en vez de **"Deivy le debe $2.077 a Anita"**. El cálculo estaba bien; el problema era de presentación.

## Cómo

- **`settlement.ts`** — nuevo campo `net: { debtor, creditor, amount } | null` en `summarizeSettlements`: monto siempre positivo, dirección que **se invierte** cuando `remainingDebt < 0`. `direction` sigue apuntando al lado del gasto (invariante intacto).
- **`balance-card.tsx`** — el titular ahora usa `net`; muestra la deuda invertida en vez de "$0". Guard en `Math.round(net.amount)` para que residuos de centavos lean como saldado.
- **`page.tsx`** — el sheet de "Registrar pago" toma dirección y monto de `net` (invertidos y positivos). De paso corrige un prefill de monto negativo latente.
- **`settlement.test.ts`** — 4 tests nuevos (dirección normal, invertida, saldado exacto, sin pagos).

## Verificación

- ✅ 254 unit tests (incluidos los 4 nuevos)
- ✅ `tsc --noEmit` limpio
- ✅ ESLint limpio
- ✅ e2e de settlement no afectados (usan pagos exactos/parciales, nunca sobrepago)

Sin migraciones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)