### PR TITLE
fix(balance): settle debt only on money that actually changed hands

### DIFF
--- a/e2e/happy-path.spec.ts
+++ b/e2e/happy-path.spec.ts
@@ -467,10 +467,12 @@ test.describe("Dashboard — balance proporcional", () => {
       await page.getByTestId("open-load-bill").click();
       await page.getByTestId("load-bill-sheet").waitFor({ state: "visible" });
 
-      // A $6.000 bill on a shared, fully-unpaid instance shifts the
-      // proportional split enough to flip the debtor and reopen a 2.000
-      // difference — see the matching Vitest fixture in settlement.test.ts
-      // for the worked math.
+      // A $6.000 bill the logged-in user fronts (the payer selector defaults
+      // to them) puts 6.000 more of shared spending on their side, so the
+      // partner owes 2.000 past what they already settled. The bill has to
+      // be ATTRIBUTED for this: an unattributed bill moves no money between
+      // the two and would leave the month settled. See the matching Vitest
+      // fixture in settlement.test.ts for the worked math.
       await page.getByTestId("load-bill-amount").fill("6000");
 
       const warning = page.getByTestId("load-bill-impact-warning");

--- a/src/app/(app)/expenses/_components/load-bill-sheet.tsx
+++ b/src/app/(app)/expenses/_components/load-bill-sheet.tsx
@@ -70,10 +70,13 @@ export function LoadBillSheet({
 
   const name = instance.fixed_expense_templates.description;
 
-  // Live reopen-warning preview (PR5) — recomputed on every keystroke, null
-  // unless the typed amount is a validly-shaped number AND actually reopens
-  // an already-settled month. previewBillImpact is pure/cheap, so no
-  // debounce is needed for a single-instance recompute.
+  // Live reopen-warning preview (PR5) — recomputed on every keystroke and on
+  // every payer switch, null unless the typed amount is a validly-shaped
+  // number AND actually reopens an already-settled month. The payer belongs
+  // in here because who fronts the bill decides which way the debt moves —
+  // the same amount can reopen the month or leave it settled depending on it.
+  // previewBillImpact is pure/cheap, so no debounce is needed for a
+  // single-instance recompute.
   const parsedDraft = parseAmount(draft);
   const impactPreview = useMemo(() => {
     if (!Number.isFinite(parsedDraft) || parsedDraft <= 0) return null;
@@ -85,8 +88,9 @@ export function LoadBillSheet({
       settlements: monthlyData.settlements,
       instanceId: instance.id,
       amount: parsedDraft,
+      payerId,
     });
-  }, [monthlyData, instance.id, parsedDraft]);
+  }, [monthlyData, instance.id, parsedDraft, payerId]);
 
   const mutation = useMutation({
     mutationFn: ({ amount, payer }: { amount: number; payer: string | null }) =>

--- a/src/lib/actions/expenses.ts
+++ b/src/lib/actions/expenses.ts
@@ -586,11 +586,17 @@ export async function markFixedExpenseInstanceAwaitingBill(
 }
 
 // "Cargar factura" — atomically prices an AWAITING_BILL instance and flips
-// it back to counted. Sets amount_override, paid_by_user_id, status=
+// it back to counted. Sets amount_override, paid, paid_by_user_id, status=
 // 'CONFIRMED', and billed_at=now() (source of truth for the "nuevo" pill,
 // PR3). Scoped to AWAITING_BILL so it can't silently reprice an
 // already-billed instance through this path — use
 // updateFixedExpenseInstanceAmount for that.
+//
+// `paid: true` is NOT redundant with `paid_by_user_id`. `actualPaidFixed`
+// (balance.ts) credits a payer only when BOTH are set, so writing the payer
+// alone recorded who the sheet calls "Quién la pagó" — past tense — while
+// never crediting them, leaving the debt overstated. Marking it paid here is
+// what makes that label true.
 //
 // PR3: the approved "Cargar factura" sheet lets the user pick WHO paid
 // (mirrors createInstallmentPurchase's payerId resolution) — PR2 hardcoded
@@ -625,6 +631,7 @@ export async function loadFixedExpenseBill(
     .from("fixed_expense_instances")
     .update({
       amount_override: amount,
+      paid: true,
       paid_by_user_id: resolvedPayerId,
       status: "CONFIRMED",
       billed_at: new Date().toISOString(),

--- a/src/lib/utils/__tests__/balance.test.ts
+++ b/src/lib/utils/__tests__/balance.test.ts
@@ -867,6 +867,209 @@ describe("calculateMonthlyBalance — payer attribution (payer-attribution)", ()
   });
 });
 
+describe("calculateMonthlyBalance — la deuda solo cubre plata realmente pagada", () => {
+  const template = {
+    id: "t-unpaid",
+    couple_id: "c1",
+    category_id: null,
+    description: "Servicio",
+    amount: 100_000,
+    due_day: 10,
+    active: true,
+    requires_monthly_review: false,
+    awaits_bill: false,
+    is_shared: true,
+    owner_user_id: null,
+    created_at: "",
+  };
+
+  function makeFixed(
+    id: string,
+    amount: number,
+    paid_by_user_id: string | null,
+  ) {
+    return {
+      id,
+      template_id: "t-unpaid",
+      couple_id: "c1",
+      month: "2026-08-01",
+      paid: paid_by_user_id !== null,
+      paid_by_user_id,
+      created_at: "",
+      status: "CONFIRMED" as string,
+      amount_override: null as number | null,
+      billed_at: null as string | null,
+      due_day: null as number | null,
+      fixed_expense_templates: { ...template, amount },
+    };
+  }
+
+  const evenIncomes = [
+    {
+      id: "i1",
+      couple_id: "c1",
+      user_id: DEIVY_ID,
+      amount: 1_000_000,
+      month: "2026-08-01",
+      created_at: "",
+    },
+    {
+      id: "i2",
+      couple_id: "c1",
+      user_id: ANNIE_ID,
+      amount: 1_000_000,
+      month: "2026-08-01",
+      created_at: "",
+    },
+  ];
+
+  it("no inventa deudor cuando ningún gasto compartido tiene pagador", () => {
+    const result = calculateMonthlyBalance({
+      incomes: evenIncomes,
+      installmentPurchases: [],
+      fixedExpenseInstances: [makeFixed("f1", 100_000, null)],
+      variableExpenses: [],
+    });
+
+    // Ambos quedan cortos contra su obligación, pero nadie le adelantó plata
+    // al otro: no hay transferencia posible.
+    for (const b of result.balances) {
+      expect(b.netBalance).toBeLessThan(0);
+    }
+    expect(result.debtor).toBeNull();
+    expect(result.creditor).toBeNull();
+    expect(result.debtAmount).toBe(0);
+  });
+
+  it("cobra solo la mitad del gasto que el otro sí adelantó, no el pozo entero", () => {
+    const result = calculateMonthlyBalance({
+      incomes: evenIncomes,
+      installmentPurchases: [],
+      fixedExpenseInstances: [
+        makeFixed("f2a", 100_000, ANNIE_ID),
+        makeFixed("f2b", 100_000, null),
+      ],
+      variableExpenses: [],
+    });
+
+    expect(result.debtor).toBe(DEIVY_ID);
+    expect(result.creditor).toBe(ANNIE_ID);
+    expect(result.debtAmount).toBeCloseTo(50_000, 2);
+  });
+
+  it("no cambia el resultado cuando todo gasto compartido tiene pagador", () => {
+    const result = calculateMonthlyBalance({
+      incomes: evenIncomes,
+      installmentPurchases: [],
+      fixedExpenseInstances: [
+        makeFixed("f3a", 100_000, ANNIE_ID),
+        makeFixed("f3b", 40_000, DEIVY_ID),
+      ],
+      variableExpenses: [],
+    });
+
+    // Los netBalance ya suman cero, así que settlementNet los deja intactos.
+    for (const b of result.balances) {
+      expect(b.settlementNet).toBeCloseTo(b.netBalance, 6);
+    }
+    expect(result.debtor).toBe(DEIVY_ID);
+    expect(result.debtAmount).toBeCloseTo(30_000, 2);
+  });
+
+  it("regresión prod agosto 2026: 6 de 7 fijos sin pagador no inflan la deuda", () => {
+    const incomes = [
+      {
+        id: "i1",
+        couple_id: "c1",
+        user_id: DEIVY_ID,
+        amount: 3_640_000,
+        month: "2026-08-01",
+        created_at: "",
+      },
+      {
+        id: "i2",
+        couple_id: "c1",
+        user_id: ANNIE_ID,
+        amount: 1_970_000,
+        month: "2026-08-01",
+        created_at: "",
+      },
+    ];
+    const fixedExpenseInstances = [
+      makeFixed("aguas", 31_373.17, null),
+      makeFixed("cable", 43_774.55, null),
+      makeFixed("epec", 192_943.5, ANNIE_ID),
+      makeFixed("expensas", 26_292, null),
+      makeFixed("guardia", 48_000, null),
+      makeFixed("seguros", 96_991, null),
+      makeFixed("seguros-otro", 84_034, null),
+    ];
+    const installmentPurchases = [
+      {
+        id: "p1",
+        couple_id: "c1",
+        category_id: null,
+        credit_card: null,
+        card_id: null,
+        auto_renew: false,
+        description: "Aire Acondicionado",
+        total_amount: 1_320_004,
+        installments: 24,
+        paid_installments: 22,
+        first_payment_date: "2025-09-01",
+        created_at: "",
+        paid_by_user_id: DEIVY_ID as string | null,
+      },
+      {
+        id: "p2",
+        couple_id: "c1",
+        category_id: null,
+        credit_card: null,
+        card_id: null,
+        auto_renew: false,
+        description: "Ventiladores",
+        total_amount: 500_475,
+        installments: 9,
+        paid_installments: 5,
+        first_payment_date: "2026-01-01",
+        created_at: "",
+        paid_by_user_id: DEIVY_ID as string | null,
+      },
+    ];
+    const variableExpenses = [
+      {
+        id: "v1",
+        couple_id: "c1",
+        category_id: null,
+        user_id: DEIVY_ID,
+        description: "Fiambreria",
+        amount: 30_750,
+        is_shared: true,
+        date: "2026-08-01",
+        created_at: "",
+      },
+    ];
+
+    const result = calculateMonthlyBalance({
+      incomes,
+      installmentPurchases,
+      fixedExpenseInstances,
+      variableExpenses,
+    });
+
+    // Las tarjetas por persona siguen midiendo contra el total del mes.
+    expect(
+      result.balances.find((b) => b.userId === DEIVY_ID)!.obligation,
+    ).toBeCloseTo(431_327.81, 1);
+
+    // La deuda, en cambio, se mide contra los $334.301,50 que sí se pagaron:
+    // el bug reportado mostraba $289.970.
+    expect(result.debtor).toBe(DEIVY_ID);
+    expect(result.creditor).toBe(ANNIE_ID);
+    expect(result.debtAmount).toBeCloseTo(75_550.64, 1);
+  });
+});
+
 describe("billedFixedAmount", () => {
   const baseTemplate = {
     id: "t1",

--- a/src/lib/utils/__tests__/settlement.test.ts
+++ b/src/lib/utils/__tests__/settlement.test.ts
@@ -348,6 +348,7 @@ describe("previewBillImpact", () => {
       settlements: [],
       instanceId: "fi-awaiting",
       amount: 30_000,
+      payerId: DEIVY_ID,
     });
     expect(result).toBeNull();
   });
@@ -373,6 +374,7 @@ describe("previewBillImpact", () => {
       settlements: [],
       instanceId: "fi-awaiting",
       amount: 0,
+      payerId: DEIVY_ID,
     });
     expect(result).toBeNull();
   });
@@ -380,6 +382,7 @@ describe("previewBillImpact", () => {
   it("warns with the exact difference when loading a bill reopens a saldado month", () => {
     // Deivy 100k, Annie 50k income; a 30k shared variable expense paid by
     // Deivy creates a 10k debt Annie owes Deivy — settled by one settlement.
+    // Loading a 6k bill Deivy also fronts pushes Annie 2k back into debt.
     const incomes = [
       {
         id: "1",
@@ -433,12 +436,75 @@ describe("previewBillImpact", () => {
       settlements,
       instanceId: "fi-awaiting",
       amount: 6_000,
+      payerId: DEIVY_ID,
     });
 
     expect(result).not.toBeNull();
     expect(result?.currentRemainingDebt).toBe(0);
     expect(result?.projectedRemainingDebt).toBe(2_000);
     expect(result?.difference).toBe(2_000);
+  });
+
+  it("returns null when the bill has no payer — an uncredited expense moves no debt between people", () => {
+    // Same setup as the test above, but nobody is attributed the bill. Since
+    // `settlementNet` only ever moves on money that actually left a pocket,
+    // an unattributed bill cannot reopen a settled month.
+    const incomes = [
+      {
+        id: "1",
+        couple_id: "c1",
+        user_id: DEIVY_ID,
+        amount: 100_000,
+        month: "2026-08-01",
+        created_at: "",
+      },
+      {
+        id: "2",
+        couple_id: "c1",
+        user_id: ANNIE_ID,
+        amount: 50_000,
+        month: "2026-08-01",
+        created_at: "",
+      },
+    ];
+    const variables: Parameters<
+      typeof calculateMonthlyBalance
+    >[0]["variableExpenses"] = [
+      {
+        id: "v1",
+        couple_id: "c1",
+        user_id: DEIVY_ID,
+        description: "Super",
+        amount: 30_000,
+        date: "2026-08-05",
+        category_id: null,
+        is_shared: true,
+        created_at: "",
+      },
+    ];
+    const awaitingInstance = {
+      ...baseFixedInstances[0],
+      id: "fi-awaiting",
+      paid: false,
+      paid_by_user_id: null,
+      amount_override: null,
+      status: "AWAITING_BILL",
+    };
+
+    const result = previewBillImpact({
+      incomes,
+      installmentPurchases: baseInstallments,
+      fixedExpenseInstances: [awaitingInstance],
+      variableExpenses: variables,
+      settlements: [
+        { from_user_id: ANNIE_ID, to_user_id: DEIVY_ID, amount: 10_000 },
+      ],
+      instanceId: "fi-awaiting",
+      amount: 6_000,
+      payerId: null,
+    });
+
+    expect(result).toBeNull();
   });
 });
 

--- a/src/lib/utils/balance.ts
+++ b/src/lib/utils/balance.ts
@@ -89,12 +89,27 @@ export function billedFixedAmount(instance: BilledInstance): number {
   );
 }
 
+/**
+ * A net below this (in pesos) is floating-point noise, not a debt. Percentages
+ * are irrational-ish ratios (364/561 and friends), so `settlementNet` lands on
+ * ±1e-11 instead of exactly 0 on a perfectly balanced month — without a floor,
+ * that noise would name a debtor for a fraction of a centavo.
+ */
+const SETTLEMENT_EPSILON = 0.005;
+
 export interface PersonBalance {
   userId: string;
   percentage: number;
   obligation: number;
   actualPaid: number;
   netBalance: number; // positive = overpaid, negative = owes
+  /**
+   * `netBalance` re-baselined so the couple's nets sum to zero — the only
+   * figure a person-to-person settlement may be derived from. See the block
+   * comment above the `settlementNet` computation for why the raw
+   * `netBalance` cannot serve that role.
+   */
+  settlementNet: number;
 }
 
 export interface MonthlyBalance {
@@ -185,7 +200,7 @@ export function calculateMonthlyBalance(params: {
     installmentTotal + fixedSharedTotal + variableSharedTotal;
   const savingsCapacity = totalIncome - totalExpenses;
 
-  const balances: PersonBalance[] = incomes.map((income) => {
+  const rawBalances = incomes.map((income) => {
     const percentage =
       totalIncome > 0 ? Number(income.amount) / totalIncome : 0;
     const obligation = percentage * sharedExpensesTotal;
@@ -224,11 +239,41 @@ export function calculateMonthlyBalance(params: {
     };
   });
 
+  // `obligation` — and therefore `netBalance` — measures each person against
+  // the month's FULL shared total, unpaid bills included. That is the right
+  // number for "cuánto me toca este mes", but it is NOT a debt between two
+  // people: when a shared expense has no payer, nobody fronted it, so the
+  // netBalances stop summing to zero and BOTH partners can come out negative.
+  // Settling off the raw netBalance then bills the higher earner for their
+  // share of the unpaid pot as if the partner had covered it (prod bug,
+  // 2026-08: "Deivy le debe a Annie $289.970" while Annie was $40.494 short
+  // herself).
+  //
+  // A transfer can only ever be about money that ACTUALLY left a pocket, so
+  // re-baseline each net against the shared shortfall:
+  //
+  //   settlementNet_i = netBalance_i - percentage_i * totalNet
+  //                   = actualPaid_i - percentage_i * totalActuallyPaid
+  //
+  // These sum to zero by construction. When every shared expense has a payer
+  // `totalNet` is 0, so `settlementNet === netBalance` and the pre-existing
+  // behaviour is untouched.
+  const totalNet = rawBalances.reduce((sum, b) => sum + b.netBalance, 0);
+  const balances: PersonBalance[] = rawBalances.map((b) => ({
+    ...b,
+    settlementNet: b.netBalance - b.percentage * totalNet,
+  }));
+
   // Who owes whom
-  const sorted = [...balances].sort((a, b) => a.netBalance - b.netBalance);
-  const debtor = sorted[0]?.netBalance < 0 ? sorted[0].userId : null;
+  const sorted = [...balances].sort(
+    (a, b) => a.settlementNet - b.settlementNet,
+  );
+  const debtor =
+    sorted[0] && sorted[0].settlementNet < -SETTLEMENT_EPSILON
+      ? sorted[0].userId
+      : null;
   const creditor = debtor ? sorted.at(-1)!.userId : null;
-  const debtAmount = debtor ? Math.abs(sorted[0].netBalance) : 0;
+  const debtAmount = debtor ? Math.abs(sorted[0].settlementNet) : 0;
 
   return {
     totalIncome,

--- a/src/lib/utils/settlement.ts
+++ b/src/lib/utils/settlement.ts
@@ -182,6 +182,14 @@ export interface BillImpactPreview {
  * Recomputes Debt" — the reopen warning is specifically for a month that
  * WAS at or below zero), or loading the bill doesn't actually reopen it
  * (`projectedRemainingDebt === 0`).
+ *
+ * `payerId` is REQUIRED (nullable, not optional) because the hypothetical
+ * must mirror every column `loadFixedExpenseBill` writes — `amount_override`,
+ * `status`, `paid`, AND `paid_by_user_id`. Projecting the amount without the
+ * payer would preview an expense nobody paid, and since `settlementNet` only
+ * moves on money that actually left a pocket, that preview is always "no
+ * change" — the warning would silently never fire. A `null` payer models
+ * exactly that uncredited case rather than hiding it.
  */
 export function previewBillImpact(params: {
   incomes: Income[];
@@ -191,6 +199,7 @@ export function previewBillImpact(params: {
   settlements: Settlement[];
   instanceId: string;
   amount: number;
+  payerId: string | null;
 }): BillImpactPreview | null {
   const {
     incomes,
@@ -200,6 +209,7 @@ export function previewBillImpact(params: {
     settlements,
     instanceId,
     amount,
+    payerId,
   } = params;
 
   const currentBalance = calculateMonthlyBalance({
@@ -219,7 +229,13 @@ export function previewBillImpact(params: {
 
   const hypotheticalInstances = fixedExpenseInstances.map((instance) =>
     instance.id === instanceId
-      ? { ...instance, status: "CONFIRMED", amount_override: amount }
+      ? {
+          ...instance,
+          status: "CONFIRMED",
+          amount_override: amount,
+          paid: payerId !== null,
+          paid_by_user_id: payerId,
+        }
       : instance,
   );
   const projectedBalance = calculateMonthlyBalance({


### PR DESCRIPTION
## Summary

- The dashboard reported a person-to-person debt that included shared expenses **nobody had paid yet**. In prod (agosto 2026) it read *"Deivy le debe a Annie $289.970"* while Annie was $40.494 short of her own obligation — six of seven fixed instances had no payer. The real transfer was **$75.550,64**.
- `debtor`/`creditor`/`debtAmount` now derive from a new `settlementNet` that only moves on money which actually left a pocket.
- That made debt invariant to unpaid expenses, which exposed a second defect: **"Cargar factura" recorded who paid and then never credited them.**

## The math

`obligation` measures each person against the month's FULL shared total, unpaid bills included. That is correct for *"cuánto me toca este mes"* — but it is not a debt between two people. An expense with no payer was fronted by nobody, so the netBalances stop summing to zero and **both** partners can come out negative. `debtAmount` took `|min netBalance|` regardless, billing the higher earner for their share of the unpaid pot as if their partner had covered it.

```
settlementNet_i = netBalance_i - percentage_i * totalNet
                = actualPaid_i - percentage_i * totalActuallyPaid
```

These sum to zero by construction. When every shared expense has a payer, `totalNet` is 0 and `settlementNet === netBalance` — existing behaviour untouched. `netBalance` itself is unchanged and still drives the per-person cards, which were always correct.

Note `min(|debtorNet|, creditorNet)` is **not** an equivalent fix — it returns 0 for the prod case.

## The second defect

`loadFixedExpenseBill` wrote `paid_by_user_id` but not `paid`, and `actualPaidFixed` requires both. So the sheet labelled **"Quién la pagó"** (past tense) recorded a payer who was never credited, leaving the debt overstated. It now writes `paid: true` — which is the state `e2e/pending-bills.spec.ts:331` already seeded, with the comment *"simulates the state a real 'Cargar factura' would have left"*. The e2e assumed the fixed behaviour before the action did it.

`previewBillImpact` gains a **required** `payerId` (nullable, not optional) and projects `paid` + `paid_by_user_id`, mirroring every column the action writes. Required on purpose: an unattributed bill moves no money between partners, so omitting the payer would leave the reopen warning permanently dead rather than merely wrong.

## Changes

| File | Change |
|------|--------|
| `src/lib/utils/balance.ts` | `settlementNet` on `PersonBalance`; debtor/creditor/debtAmount derive from it; `SETTLEMENT_EPSILON` floors float noise |
| `src/lib/actions/expenses.ts` | `loadFixedExpenseBill` also writes `paid: true` |
| `src/lib/utils/settlement.ts` | `previewBillImpact` takes a required `payerId` and projects the payer |
| `src/app/(app)/expenses/_components/load-bill-sheet.tsx` | Passes `payerId`; added to `useMemo` deps so switching payer recomputes the warning |
| `src/lib/utils/__tests__/balance.test.ts` | 4 tests, incl. a regression with the real prod agosto 2026 figures |
| `src/lib/utils/__tests__/settlement.test.ts` | 2 tests: attributed bill reopens the month, unattributed one does not |
| `e2e/happy-path.spec.ts` | Comment corrected — it described the old mechanism |

## SDD Traceability

`size:exception` — single-defect production bug fix found by inspecting live data, not a planned SDD change.

## QA Gate

- [ ] `sdd-verify` not run — not an SDD change (see above)
- [x] No new/changed e2e specs needed; existing coverage still applies
- [ ] CI checks green — **pending on this PR**
- [x] No visual/a11y changes

Locally verified: **259/259 vitest**, `tsc --noEmit` clean, `eslint` clean. `balance.ts` and `settlement.ts` at **100% line coverage**. Playwright e2e **not run locally** (needs local Supabase) — relying on CI for those.

## Release / Deploy

- [x] No Supabase migrations in this PR.

⚠️ **Historical data is not backfilled.** Bills loaded through the broken flow kept `paid_by_user_id` set with `paid = false`, so those payers were never credited. Agosto is clean; earlier months were not audited. Worth a follow-up query before deciding whether a data migration is warranted.
