### PR TITLE
feat(services): let a servicio's category be edited, not only set at creation

### DIFF
--- a/e2e/service-category.spec.ts
+++ b/e2e/service-category.spec.ts
@@ -1,0 +1,168 @@
+import { test, expect } from "./fixtures";
+
+/**
+ * Editing a servicio's category.
+ *
+ * `updateFixedExpenseTemplate` accepted `category_id` from the start, and the
+ * create form has always had a picker — but the edit sheet never rendered one,
+ * so a servicio could be categorised once and never again. That dead-ended the
+ * whole point of making "Sin categoría" navigable: you could finally FIND the
+ * uncategorised services and still not fix them.
+ *
+ * Category is template-level, so it saves on pick rather than riding the
+ * amount/due-day submit — which an AWAITING_BILL instance never reaches, and
+ * those are exactly the ones most likely to be missing a category.
+ */
+
+const currentMonth = (): string => {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-01`;
+};
+
+const templateCreatedAt = (): string => {
+  const now = new Date();
+  return new Date(now.getFullYear() - 1, 0, 1).toISOString();
+};
+
+test.describe("Servicio — editar categoría desde el sheet", () => {
+  const DESC = `E2E-svc-cat-${Date.now()}`;
+  let templateId: string;
+  let categoryId: string;
+  let categoryName: string;
+
+  test.beforeEach(async ({ adminClient, coupleId }) => {
+    const { data: category } = await adminClient
+      .from("expense_categories")
+      .select("id, name")
+      .order("sort_order")
+      .limit(1)
+      .single();
+    if (!category) throw new Error("No expense_categories seeded");
+    categoryId = category.id;
+    categoryName = category.name;
+
+    // Seeded WITHOUT a category — the state the user is trying to fix.
+    const { data: template, error } = await adminClient
+      .from("fixed_expense_templates")
+      .insert({
+        couple_id: coupleId,
+        description: DESC,
+        amount: 72_375,
+        due_day: 25,
+        awaits_bill: false,
+        category_id: null,
+        created_at: templateCreatedAt(),
+      })
+      .select("id")
+      .single();
+    if (error || !template)
+      throw new Error(`Template seed failed: ${error?.message}`);
+    templateId = template.id;
+
+    await adminClient.from("fixed_expense_instances").insert({
+      template_id: templateId,
+      couple_id: coupleId,
+      month: currentMonth(),
+      paid: false,
+      status: "CONFIRMED",
+    });
+  });
+
+  test.afterEach(async ({ adminClient }) => {
+    if (templateId) {
+      await adminClient
+        .from("fixed_expense_instances")
+        .delete()
+        .eq("template_id", templateId);
+      await adminClient
+        .from("fixed_expense_templates")
+        .delete()
+        .eq("id", templateId);
+    }
+  });
+
+  test("asignar una categoría a un servicio la persiste en el template", async ({
+    authenticatedPage: page,
+    adminClient,
+  }) => {
+    test.slow();
+    await page.goto("/expenses");
+    await page.waitForLoadState("networkidle", { timeout: 12_000 });
+    await page.getByTestId("tab-servicios").click();
+    await expect(page.getByText(DESC)).toBeVisible({ timeout: 10_000 });
+
+    // The sheet opens from the "Vence día" line, not from "Editar monto" —
+    // that one swaps the amount for an inline editor and never opens a modal.
+    const row = page.locator("div").filter({ hasText: DESC }).first();
+    await row
+      .getByRole("button", { name: "Editar día de vencimiento" })
+      .click();
+    await expect(page.getByTestId("edit-service-sheet")).toBeVisible();
+
+    // The picker exists at all — this is what was missing.
+    const picker = page.getByTestId("edit-service-category");
+    await expect(picker).toBeVisible();
+
+    await picker.getByRole("radio", { name: categoryName }).click();
+
+    // Saves on pick: no "Guardar" involved, the template already has it.
+    await expect
+      .poll(
+        async () => {
+          const { data } = await adminClient
+            .from("fixed_expense_templates")
+            .select("category_id")
+            .eq("id", templateId)
+            .maybeSingle();
+          return data?.category_id ?? null;
+        },
+        { timeout: 8_000 },
+      )
+      .toBe(categoryId);
+  });
+
+  test("un servicio sin factura también puede categorizarse", async ({
+    authenticatedPage: page,
+    adminClient,
+  }) => {
+    test.slow();
+    // AWAITING_BILL skips the amount branch of the submit entirely, so a
+    // category batched into that submit would never save for these rows.
+    await adminClient
+      .from("fixed_expense_instances")
+      .update({ status: "AWAITING_BILL" })
+      .eq("template_id", templateId);
+
+    await page.goto("/expenses");
+    await page.waitForLoadState("networkidle", { timeout: 12_000 });
+    await page.getByTestId("tab-servicios").click();
+    await expect(page.getByText(DESC)).toBeVisible({ timeout: 10_000 });
+
+    // The sheet opens from the "Vence día" line, not from "Editar monto" —
+    // that one swaps the amount for an inline editor and never opens a modal.
+    const row = page.locator("div").filter({ hasText: DESC }).first();
+    await row
+      .getByRole("button", { name: "Editar día de vencimiento" })
+      .click();
+    await expect(page.getByTestId("edit-service-sheet")).toBeVisible();
+
+    await page
+      .getByTestId("edit-service-category")
+      .getByRole("radio", { name: categoryName })
+      .click();
+
+    await expect
+      .poll(
+        async () => {
+          const { data } = await adminClient
+            .from("fixed_expense_templates")
+            .select("category_id")
+            .eq("id", templateId)
+            .maybeSingle();
+          return data?.category_id ?? null;
+        },
+        { timeout: 8_000 },
+      )
+      .toBe(categoryId);
+  });
+});

--- a/src/app/(app)/expenses/page.tsx
+++ b/src/app/(app)/expenses/page.tsx
@@ -60,6 +60,7 @@ import { DueDayPicker } from "./_components/due-day-picker";
 import { toast } from "sonner";
 import { ResponsiveModal } from "@/components/shared/responsive-modal";
 import { ConfirmDialog } from "@/components/shared/confirm-dialog";
+import { CategoryPicker } from "@/components/shared/category-picker";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 
@@ -491,6 +492,10 @@ function EditServiceSheet({
   const [awaitsBill, setAwaitsBill] = useState(
     instance.fixed_expense_templates.awaits_bill,
   );
+  const { data: categories = [] } = useCategories(coupleId);
+  const [categoryId, setCategoryId] = useState<string | null>(
+    instance.fixed_expense_templates.category_id,
+  );
 
   const {
     register,
@@ -557,6 +562,29 @@ function EditServiceSheet({
     onError: () => {
       // Revert the optimistic local toggle on failure.
       setAwaitsBill((prev) => !prev);
+    },
+  });
+
+  // Category is template-level, like awaits_bill, so it saves on pick rather
+  // than riding the submit below — which an AWAITING_BILL instance never
+  // reaches, and those are exactly the ones most likely to need categorising.
+  // `updateFixedExpenseTemplate` already accepted `category_id`; only the UI
+  // to send it was missing, so a servicio could be categorised at creation
+  // and never again.
+  const categoryMutation = useMutation({
+    mutationFn: ({
+      templateId,
+      value,
+    }: {
+      templateId: string;
+      value: string | null;
+    }) => updateFixedExpenseTemplate(templateId, { category_id: value }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["monthly-data"] });
+    },
+    onError: () => {
+      // Revert the optimistic local pick, same as the awaits_bill toggle.
+      setCategoryId(instance.fixed_expense_templates.category_id);
     },
   });
 
@@ -643,6 +671,7 @@ function EditServiceSheet({
     dueDayMutation.isPending ||
     deleteMutation.isPending ||
     awaitsBillMutation.isPending ||
+    categoryMutation.isPending ||
     markAwaitingMutation.isPending;
   const name = instance.fixed_expense_templates.description;
 
@@ -763,6 +792,27 @@ function EditServiceSheet({
             )}
           </div>
         )}
+
+        {/* Category — template-level, saves on pick */}
+        <div className="mb-3.5" data-testid="edit-service-category">
+          <div
+            className="mb-1.5 block text-[13px] font-medium"
+            style={{ color: "var(--fg-2)", fontFamily: "var(--font-sans)" }}
+          >
+            Categoría
+          </div>
+          <CategoryPicker
+            categories={categories}
+            value={categoryId}
+            onChange={(id) => {
+              setCategoryId(id);
+              categoryMutation.mutate({
+                templateId: instance.template_id,
+                value: id,
+              });
+            }}
+          />
+        </div>
 
         {/* Due day edit */}
         <div className="mb-3.5">


### PR DESCRIPTION
## Summary

A servicio could be given a category when it was created and never again. Reported after #157 made "Sin categoría" navigable — which turned out to dead-end: you could finally **find** the uncategorised services and still not fix them.

## What was actually missing

Almost nothing, which is why this is small:

- `updateFixedExpenseTemplate` has accepted `category_id` since it was written (`expenses.ts:419`).
- The **create** form has always had a `CategoryPicker`.
- The **edit** sheet never rendered one.

So the action and the component both existed; only the wiring between them was absent.

## Why it saves on pick instead of on submit

Not a style preference. `handleSave` has a branch that returns early for `AWAITING_BILL` instances — they have no amount to save, so the submit skips straight past it. Those rows are exactly the ones most likely to be missing a category. Batching the category into that submit would have **silently never saved** for them.

Saving on pick is also the pattern `awaits_bill` and the paid switch already use in this sheet, revert-on-error included.

## Changes

| File | Change |
|------|--------|
| `src/app/(app)/expenses/page.tsx` | `CategoryPicker` in `EditServiceSheet`, backed by a `categoryMutation` that saves on pick and reverts on error |
| `e2e/service-category.spec.ts` | New: assigning a category persists it on the template; and the same for an `AWAITING_BILL` servicio |

## Verification

- **293/293** vitest, **126/126** playwright e2e, `tsc` and `eslint` clean — run locally against a local Supabase.
- The second e2e exists specifically to cover the `AWAITING_BILL` path, which is where a careless wiring would fail silently rather than loudly.

### A note for whoever touches this sheet next

The edit sheet opens from the **"Vence día"** line, *not* from "Editar monto" — that button swaps the amount for an inline editor in the row and never opens a modal. The first draft of these tests targeted the wrong control and timed out; the failure screenshot is what showed the real UI.

## SDD Traceability

`size:exception` — follow-up defect from real use, surfaced by the change in #157.

## QA Gate

- [ ] `sdd-verify` not run — not an SDD change
- [x] New e2e spec committed under `e2e/`
- [ ] CI checks green — pending on this PR
- [x] No visual/a11y changes beyond the added picker, which reuses the existing shared component

## Release / Deploy

- [x] No Supabase migrations.
